### PR TITLE
Feature/forge multi tenant

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -50,6 +50,9 @@ jobs:
           composer install --prefer-dist --no-progress --no-interaction
           if [ -n "$LOG_COVERAGE" ]; then mkdir -p coverage; fi
 
+      - name: Static analysis (PHPStan)
+        run: vendor/bin/phpstan analyse --no-progress
+
       - name: Run tests
         run: |
           vendor/bin/phpunit \

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^13.0",
-        "mockery/mockery": "^1.6"
+        "mockery/mockery": "^1.6",
+        "phpstan/phpstan": "^2.2"
     },
 
     "bin": [

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+    level: 5
+    paths:
+        - src

--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -6,8 +6,6 @@ use Exception;
 
 class ConfigLoader
 {
-    private array $config = [];
-
     /**
      * @throws Exception
      */


### PR DESCRIPTION
 - Adds phpstan/phpstan as a dev dependency with a phpstan.neon config targeting src/ at level 5. Wires it into CI before the test step. Also removes a dead private property in ConfigLoader that PHPStan flagged