### PR TITLE
Multi-tenant SaaS framework: resolvers, scaffolding, auth layer, and polish

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,10 +17,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.4"]
+        php: ["8.4", "8.5"]
 
     env:
-      # Collect coverage only on PRs and pushes to main — keeps all other runs fast
+      # Collect coverage only on 8.4 on PRs and pushes to main — keeps all other runs fast
       LOG_COVERAGE: "${{ fromJSON('{true: \"1\", false: \"\"}')[matrix.php == '8.4' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))] }}"
 
     steps:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.4", "8.5"]
+        php: ["8.3", "8.4", "8.5"]
 
     env:
       # Collect coverage only on 8.4 on PRs and pushes to main — keeps all other runs fast

--- a/bin/ef
+++ b/bin/ef
@@ -6,6 +6,8 @@ require __DIR__ . '/../vendor/autoload.php';
 use Symfony\Component\Console\Application;
 use EntityForge\Console\GenerateCommand;
 use EntityForge\Console\GenerateAllCommand;
+use EntityForge\Console\MakeControllerCommand;
+use EntityForge\Console\MakeMiddlewareCommand;
 use EntityForge\Console\MigrateCommand;
 use EntityForge\Console\MigrateAllTenantsCommand;
 use EntityForge\Console\RollbackCommand;
@@ -15,6 +17,8 @@ $application = new Application('EntityForge CLI', '1.0');
 
 $application->addCommand(new GenerateCommand());
 $application->addCommand(new GenerateAllCommand());
+$application->addCommand(new MakeMiddlewareCommand());
+$application->addCommand(new MakeControllerCommand());
 $application->addCommand(new MigrateCommand());
 $application->addCommand(new MigrateAllTenantsCommand());
 $application->addCommand(new RollbackCommand());

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         }
     },
     "require": {
-        "php": "^8.4",
-        "symfony/yaml": "^8.1",
-        "symfony/console": "^8.1",
+        "php": "^8.3",
+        "symfony/yaml": "^7.0",
+        "symfony/console": "^7.0",
         "ext-pdo": "*",
         "nikic/fast-route": "^1.3",
-        "symfony/process": "^8.1",
+        "symfony/process": "^7.0",
         "firebase/php-jwt": "^7.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "firebase/php-jwt": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^13.0",
+        "phpunit/phpunit": "^12.0",
         "mockery/mockery": "^1.6",
         "phpstan/phpstan": "^2.2"
     },

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -334,6 +334,10 @@ Output:
 - `app/Repository/OrderRepository.php`
 - `database/migrations/{timestamp}_create_orders_table.up.sql` + `.down.sql`
 
+`EntityBuilder` converts relation entries into typed properties on the entity class, not stub methods:
+- `belongsTo` → `public ?User $user = null;` with `use App\Entity\User;`
+- `hasMany` → `/** @var Order[] */ public array $orders = [];` with the corresponding `use`
+
 `generate:all` uses a single `EntityGenerator` instance to guarantee monotonically ordered migration timestamps within a session.
 
 ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -206,6 +206,14 @@ $request->param('id');    // single named parameter
 $request->params();       // all parameters as array
 ```
 
+Arbitrary per-request data (resolved user identity, trace IDs, etc.) is stored as attributes — set by middleware, consumed by handlers:
+
+```php
+$request->withAttribute('user', $user);   // returns new immutable instance
+$request->getAttribute('user');           // null if absent
+$request->getAttribute('user', 'guest'); // with default
+```
+
 ### Response
 
 Three output modes: immutable builder, streaming, and legacy direct-echo.
@@ -243,6 +251,14 @@ $response = $pipeline->run($request, fn(Request $req): Response => $router->disp
 ```
 
 Middleware is executed outermost-first. `$next` is a `callable(Request): Response`.
+
+### Auth integration
+
+EntityForge does not ship an auth implementation. `AuthMiddlewareInterface` (extends `MiddlewareInterface`) is the designated integration point — implement it against any provider and attach the resolved identity via `$request->withAttribute('user', $identity)`. Scaffold the stub with:
+
+```bash
+php bin/ef make:middleware FirebaseAuthMiddleware --auth
+```
 
 ### Router
 

--- a/docs/CLEANUP.md
+++ b/docs/CLEANUP.md
@@ -62,6 +62,8 @@ This document tracks deliberate gaps and deferred work in the current codebase.
 
 **Relations and indexes are supported in the generator.** `MigrationBuilder` emits `FOREIGN KEY` constraints from `relations.belongsTo` and `INDEX` / `UNIQUE INDEX` clauses from `indexes`. Both sections are optional and validated by `SchemaValidator`.
 
+**Relations generate typed entity properties.** `EntityBuilder` converts `belongsTo` into `public ?RelatedClass $property = null;` and `hasMany` into `/** @var RelatedClass[] */ public array $properties = [];`, each with the correct `use App\Entity\RelatedClass;` import injected automatically. Pluralisation handles common irregular forms (`category → categories`, `address → addresses`).
+
 ```json
 "relations": { "belongsTo": { "User": "user_id" } },
 "indexes": [

--- a/docs/CONCEPT.md
+++ b/docs/CONCEPT.md
@@ -62,11 +62,14 @@ Executes `.up.sql` files in filename order, records each in a `migrations` table
 ## Pipeline
 An immutable middleware chain. Each `pipe()` returns a new `Pipeline` instance. `run(Request, callable): Response` processes the chain outermost-first, then calls the destination handler. Middleware implements `MiddlewareInterface::handle(Request, callable): Response`.
 
+## AuthMiddlewareInterface
+A marker interface extending `MiddlewareInterface` that designates a middleware as the auth integration point. Implementations authenticate the request via any external provider and attach the resolved identity with `$request->withAttribute('user', $identity)` before calling `$next`. EntityForge does not implement auth; it defines where auth hooks in.
+
 ## Router
 A FastRoute-backed request dispatcher. Register handlers with `get()`, `post()`, `put()`, `delete()`. Paths support `{name}` parameter segments — extracted values are available via `$request->param('name')` and `$request->params()`. `dispatch(Request): Response` returns `404 Not Found` for unregistered routes and `405 Method Not Allowed` for method mismatches. Routes match in registration order.
 
 ## Request
-An immutable value object representing an HTTP request. Constructed directly or captured from PHP superglobals via `Request::capture()`. Provides `header()`, `query()`, `body()`, `method()`, `path()`, `param()`, and `params()`. Route parameters are attached by the Router via `withParams()` before the handler is called.
+An immutable value object representing an HTTP request. Constructed directly or captured from PHP superglobals via `Request::capture()`. Provides `header()`, `query()`, `body()`, `method()`, `path()`, `param()`, and `params()`. Route parameters are attached by the Router via `withParams()` before the handler is called. Arbitrary per-request data (resolved user, trace IDs) is stored as attributes via `withAttribute(key, value)` (returns a new instance) and read with `getAttribute(key, default)`.
 
 ## Response
 A tri-mode HTTP response. The immutable builder path (`withJson`, `withStatus`, `withHeader`, `send`) is used by the Pipeline and Router. `stream(callable)` sends headers then delegates output to the caller for chunk-by-chunk streaming without buffering. The legacy `json()` method echoes directly and is kept for backwards compatibility.

--- a/docs/CONCEPT.md
+++ b/docs/CONCEPT.md
@@ -4,7 +4,7 @@
 The boot entry point. Loads and merges YAML config, validates required keys, runs `CoreSchemaManager`, registers core bindings in the `Container`, and optionally resolves the current tenant. Pass `false` as the second argument to `boot()` to skip tenant resolution (used by CLI commands). Access the container via `getContainer()`.
 
 ## Entity
-A configuration-defined model described by a JSON schema in `config/entities/`. Drives generation of a PHP class, a repository, and SQL migration files.
+A configuration-defined model described by a JSON schema in `config/entities/`. Drives generation of a PHP class, a repository, and SQL migration files. Relation entries in the schema become typed properties on the generated class: `belongsTo` entries produce a nullable typed property (`public ?User $user = null;`), `hasMany` entries produce a typed array property (`/** @var Order[] */ public array $orders = [];`). Both include the appropriate `use` import.
 
 ## Repository
 A data-access layer that auto-scopes queries to the current tenant. Generated repositories extend `BaseRepository` and inherit CRUD methods, transaction support, and tenant scoping. Never reuse a repository instance across tenant switches.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,4 @@
 parameters:
-    level: 5
+    level: 8
     paths:
         - src

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          colors="true">
     <testsuites>
         <testsuite name="Unit">

--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,23 @@ database:
 }
 ```
 
-`relations.belongsTo` emits a `CONSTRAINT fk_… FOREIGN KEY` clause. `indexes` emits `INDEX` or `UNIQUE INDEX` clauses. Both are optional.
+`relations.belongsTo` emits a `CONSTRAINT fk_… FOREIGN KEY` clause in the migration and a typed nullable property on the entity class. `indexes` emits `INDEX` or `UNIQUE INDEX` clauses. Both sections are optional.
+
+The generated `app/Entity/Order.php` will contain:
+
+```php
+use App\Entity\User;
+
+class Order
+{
+    // ...fields...
+
+    /** Loaded via user_id */
+    public ?User $user = null;
+}
+```
+
+Populate the property after loading related data — the repository handles the query, the entity holds the result.
 
 ### 3. Generate and migrate
 
@@ -413,6 +429,7 @@ Pass `false` as the second argument to skip tenant resolution — required for C
 composer install
 vendor/bin/phpunit
 vendor/bin/phpunit tests/Path/To/SomeTest.php   # single file
+vendor/bin/phpstan analyse                       # static analysis — project runs clean at level 8
 ```
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -262,6 +262,11 @@ $request->method();      // 'GET', 'POST', ...
 $request->path();        // '/users/42'
 $request->param('id');   // route parameter injected by Router
 $request->params();      // all route parameters as array
+
+// Arbitrary attributes — set by middleware, read by handlers
+$request->withAttribute('user', $resolvedUser);   // returns new instance
+$request->getAttribute('user');                   // returns value or null
+$request->getAttribute('user', 'guest');          // returns default if missing
 ```
 
 ### Response
@@ -431,6 +436,58 @@ vendor/bin/phpunit
 vendor/bin/phpunit tests/Path/To/SomeTest.php   # single file
 vendor/bin/phpstan analyse                       # static analysis — project runs clean at level 8
 ```
+
+---
+
+## Integrating Auth
+
+EntityForge does not ship an auth implementation — authentication is handled by your chosen provider (Firebase Auth, Auth0, a custom JWT stack, etc.). The framework provides the integration surface.
+
+### 1. Scaffold an auth middleware
+
+```bash
+php bin/ef make:middleware FirebaseAuthMiddleware --auth
+```
+
+This generates `app/Http/Middleware/FirebaseAuthMiddleware.php` implementing `AuthMiddlewareInterface` with annotated steps:
+
+```php
+public function handle(Request $request, callable $next): Response
+{
+    // 1. Extract credentials (e.g. Bearer token)
+    $token = $request->header('Authorization');
+
+    // 2. Verify with your provider
+    $user = $this->firebaseAuth->verifyIdToken($token);
+
+    // 3. Attach the identity and pass downstream
+    return $next($request->withAttribute('user', $user));
+
+    // 4. On failure, return early
+    // return (new Response())->withStatus(401)->withJson(['error' => 'Unauthorized']);
+}
+```
+
+### 2. Read the identity in handlers
+
+```php
+$router->get('/me', function (Request $req): Response {
+    $user = $req->getAttribute('user');   // set by auth middleware upstream
+    return (new Response())->withJson($user);
+});
+```
+
+### 3. Wire into the pipeline
+
+```php
+$pipeline = (new Pipeline())
+    ->pipe(new FirebaseAuthMiddleware($firebaseAuth))
+    ->pipe(new TenantMiddleware());
+
+$response = $pipeline->run(Request::capture(), fn($req) => $router->dispatch($req));
+```
+
+Auth runs before tenant resolution if the tenant ID is embedded in the token. Reverse the order if the tenant is resolved from the URL and auth is tenant-scoped.
 
 ---
 

--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -7,6 +7,7 @@ use Exception;
 class ConfigLoader
 {
     /**
+     * @return array<string, mixed>
      * @throws Exception
      */
     public function load(string $path): array
@@ -19,11 +20,15 @@ class ConfigLoader
 
         return match ($extension) {
             'yaml', 'yml' => Yaml::parseFile($path),
-            'json' => json_decode(file_get_contents($path), true),
+            'json' => json_decode((string) file_get_contents($path), true),
             default => throw new \Exception("Unsupported config format: {$extension}")
         };
     }
 
+    /**
+     * @param array<int, string> $paths
+     * @return array<string, mixed>
+     */
     public function loadMultiple(array $paths): array
     {
         $merged = [];

--- a/src/Config/ConfigValidator.php
+++ b/src/Config/ConfigValidator.php
@@ -8,6 +8,7 @@ class ConfigValidator
     private const REQUIRED_DB_KEYS = ['driver', 'host', 'port', 'database', 'username', 'password'];
 
     /**
+     * @param array<string, mixed> $config
      * @throws Exception
      */
     public function validate(array $config): void

--- a/src/Console/GenerateAllCommand.php
+++ b/src/Console/GenerateAllCommand.php
@@ -50,7 +50,7 @@ class GenerateAllCommand extends Command
                 if (!isset($configs[$dep])) {
                     continue; // referenced entity not in this batch — skip
                 }
-                $visit($dep);
+                $visit((string) $dep);
             }
 
             $visited[$name] = 'done';
@@ -84,7 +84,7 @@ class GenerateAllCommand extends Command
 
         $configs = [];
         foreach ($files as $file) {
-            $config = json_decode(file_get_contents($file), true);
+            $config = json_decode((string) file_get_contents($file), true);
             if (!$config) {
                 $output->writeln("<error>Invalid JSON: {$file}</error>");
                 continue;

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -35,7 +35,7 @@ class GenerateCommand extends Command
             return Command::FAILURE;
         }
 
-        $config = json_decode(file_get_contents($configPath), true);
+        $config = json_decode((string) file_get_contents($configPath), true);
 
         if (!$config) {
             $output->writeln("<error>Invalid JSON config</error>");

--- a/src/Console/MakeControllerCommand.php
+++ b/src/Console/MakeControllerCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace EntityForge\Console;
+
+use EntityForge\Generator\Builder\ControllerBuilder;
+use EntityForge\Generator\Writer\FileWriter;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MakeControllerCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('make:controller')
+            ->setDescription('Scaffold a new controller class with CRUD stubs')
+            ->addArgument('name', InputArgument::REQUIRED, 'Controller class name (e.g. UserController)')
+            ->addOption('output', null, InputOption::VALUE_OPTIONAL, 'Output directory', 'app/Http/Controller');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $name = (string) $input->getArgument('name');
+        $outputDir = (string) $input->getOption('output');
+
+        if (!preg_match('/^[A-Za-z][A-Za-z0-9]*$/', $name)) {
+            $output->writeln("<error>Invalid controller name '{$name}': use PascalCase letters and numbers only.</error>");
+            return Command::FAILURE;
+        }
+
+        $code = (new ControllerBuilder())->build($name);
+        $path = "{$outputDir}/{$name}.php";
+
+        (new FileWriter())->write($path, $code);
+
+        $output->writeln("<info>Created {$path}</info>");
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Console/MakeMiddlewareCommand.php
+++ b/src/Console/MakeMiddlewareCommand.php
@@ -18,7 +18,8 @@ class MakeMiddlewareCommand extends Command
             ->setName('make:middleware')
             ->setDescription('Scaffold a new middleware class')
             ->addArgument('name', InputArgument::REQUIRED, 'Middleware class name (e.g. AuthMiddleware)')
-            ->addOption('output', null, InputOption::VALUE_OPTIONAL, 'Output directory', 'app/Http/Middleware');
+            ->addOption('output', null, InputOption::VALUE_OPTIONAL, 'Output directory', 'app/Http/Middleware')
+            ->addOption('auth', null, InputOption::VALUE_NONE, 'Scaffold an auth middleware stub (implements AuthMiddlewareInterface)');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -31,7 +32,8 @@ class MakeMiddlewareCommand extends Command
             return Command::FAILURE;
         }
 
-        $code = (new MiddlewareBuilder())->build($name);
+        $builder = new MiddlewareBuilder();
+        $code = $input->getOption('auth') ? $builder->buildAuth($name) : $builder->build($name);
         $path = "{$outputDir}/{$name}.php";
 
         (new FileWriter())->write($path, $code);

--- a/src/Console/MakeMiddlewareCommand.php
+++ b/src/Console/MakeMiddlewareCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace EntityForge\Console;
+
+use EntityForge\Generator\Builder\MiddlewareBuilder;
+use EntityForge\Generator\Writer\FileWriter;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MakeMiddlewareCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('make:middleware')
+            ->setDescription('Scaffold a new middleware class')
+            ->addArgument('name', InputArgument::REQUIRED, 'Middleware class name (e.g. AuthMiddleware)')
+            ->addOption('output', null, InputOption::VALUE_OPTIONAL, 'Output directory', 'app/Http/Middleware');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $name = (string) $input->getArgument('name');
+        $outputDir = (string) $input->getOption('output');
+
+        if (!preg_match('/^[A-Za-z][A-Za-z0-9]*$/', $name)) {
+            $output->writeln("<error>Invalid middleware name '{$name}': use PascalCase letters and numbers only.</error>");
+            return Command::FAILURE;
+        }
+
+        $code = (new MiddlewareBuilder())->build($name);
+        $path = "{$outputDir}/{$name}.php";
+
+        (new FileWriter())->write($path, $code);
+
+        $output->writeln("<info>Created {$path}</info>");
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Console/MigrateAllTenantsCommand.php
+++ b/src/Console/MigrateAllTenantsCommand.php
@@ -96,6 +96,9 @@ class MigrateAllTenantsCommand extends Command
         return $failed > 0 ? Command::FAILURE : Command::SUCCESS;
     }
 
+    /**
+     * @param array<string, mixed> $config
+     */
     private function migrateTenant(
         string $tenantId,
         array $config,

--- a/src/Core/Application.php
+++ b/src/Core/Application.php
@@ -13,7 +13,8 @@ use Exception;
 
 class Application
 {
-    private array $config;
+    /** @var array<string, mixed> */
+    private array $config = [];
     private string $configPath;
     private Container $container;
 
@@ -24,6 +25,7 @@ class Application
     }
 
     /**
+     * @param array<string, mixed> $context
      * @throws Exception
      */
     public function boot(array $context = [], bool $resolveTenant = true): void
@@ -86,7 +88,7 @@ class Application
      */
     private function assertTenantActive(): void
     {
-        $tenantId = TenantContext::getTenantId();
+        $tenantId = TenantContext::getTenantId() ?? throw new Exception("Tenant not resolved.");
         $repo = new TenantRepository($this->config);
         $tenant = $repo->findByTenantId($tenantId);
 
@@ -100,6 +102,7 @@ class Application
     }
 
     /**
+     * @param array<string, mixed> $context
      * @throws Exception
      */
     private function resolveTenant(array $context): void
@@ -116,6 +119,7 @@ class Application
     }
 
     /**
+     * @return array<string, mixed>
      * @throws Exception
      */
     public function getConfig(): array

--- a/src/Core/Container.php
+++ b/src/Core/Container.php
@@ -4,8 +4,11 @@ namespace EntityForge\Core;
 
 class Container
 {
+    /** @var array<string, callable(Container): mixed> */
     private array $bindings   = [];
+    /** @var array<string, callable(Container): mixed> */
     private array $singletons = [];
+    /** @var array<string, mixed> */
     private array $instances  = [];
 
     public function bind(string $abstract, callable $factory): void

--- a/src/Core/CoreSchemaManager.php
+++ b/src/Core/CoreSchemaManager.php
@@ -9,6 +9,7 @@ class CoreSchemaManager
 {
     private PDO $pdo;
 
+    /** @param array<string, mixed> $config */
     public function __construct(array $config)
     {
         $this->pdo = (new Connection($config['database']))->getPdo();
@@ -22,7 +23,7 @@ class CoreSchemaManager
     }
 
     /**
-     * Define all core tables here
+     * @return array<int, string>
      */
     private function definitions(): array
     {

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -9,6 +9,7 @@ class Connection
 {
     private PDO $pdo;
 
+    /** @param array<string, mixed> $config */
     public function __construct(array $config)
     {
         try {

--- a/src/Database/MigrationRunner.php
+++ b/src/Database/MigrationRunner.php
@@ -21,7 +21,7 @@ class MigrationRunner
             $this->ensureMigrationsTable();
         }
 
-        $files = glob($path . '/*.up.sql');
+        $files = glob($path . '/*.up.sql') ?: [];
         sort($files);
 
         if (empty($files)) {
@@ -41,11 +41,14 @@ class MigrationRunner
                 continue;
             }
 
-            $sql = file_get_contents($file);
-
             if ($dryRun) {
                 echo "{$prefix}Would execute: {$name}\n";
                 continue;
+            }
+
+            $sql = file_get_contents($file);
+            if ($sql === false) {
+                throw new \Exception("Cannot read migration file: {$file}");
             }
 
             try {
@@ -85,11 +88,14 @@ class MigrationRunner
                 throw new \Exception("Missing down file: {$down}");
             }
 
-            $sql = file_get_contents($down);
-
             if ($dryRun) {
                 echo "{$prefix}Would roll back: {$migration}\n";
                 continue;
+            }
+
+            $sql = file_get_contents($down);
+            if ($sql === false) {
+                throw new \Exception("Cannot read rollback file: {$down}");
             }
 
             try {
@@ -112,7 +118,6 @@ class MigrationRunner
     {
         $pdo = $this->connection->getPdo();
 
-        // Create table if not exists
         $pdo->exec("
         CREATE TABLE IF NOT EXISTS migrations (
             id INT AUTO_INCREMENT PRIMARY KEY,
@@ -121,8 +126,10 @@ class MigrationRunner
         )
     ");
 
-        // Check if 'batch' column exists
         $stmt = $pdo->query("SHOW COLUMNS FROM migrations LIKE 'batch'");
+        if ($stmt === false) {
+            throw new \Exception("Failed to check migrations table schema.");
+        }
         $column = $stmt->fetch();
 
         if (!$column) {
@@ -130,13 +137,21 @@ class MigrationRunner
         }
     }
 
+    /**
+     * @return array<int, string>
+     */
     private function getExecuted(): array
     {
-        return $this->connection->getPdo()
-            ->query("SELECT migration FROM migrations")
-            ->fetchAll(PDO::FETCH_COLUMN);
+        $stmt = $this->connection->getPdo()->query("SELECT migration FROM migrations");
+        if ($stmt === false) {
+            throw new \Exception("Failed to query migrations table.");
+        }
+        return $stmt->fetchAll(PDO::FETCH_COLUMN);
     }
 
+    /**
+     * @return array<int, string>
+     */
     private function getExecutedSafe(): array
     {
         try {
@@ -161,12 +176,18 @@ class MigrationRunner
     private function nextBatch(): int
     {
         $stmt = $this->connection->getPdo()->query("SELECT MAX(batch) FROM migrations");
+        if ($stmt === false) {
+            throw new \Exception("Failed to query migration batch.");
+        }
         return ((int) $stmt->fetchColumn()) + 1;
     }
 
     private function lastBatch(): int
     {
         $stmt = $this->connection->getPdo()->query("SELECT MAX(batch) FROM migrations");
+        if ($stmt === false) {
+            throw new \Exception("Failed to query migration batch.");
+        }
         return (int) $stmt->fetchColumn();
     }
 }

--- a/src/Database/MigrationRunner.php
+++ b/src/Database/MigrationRunner.php
@@ -47,9 +47,9 @@ class MigrationRunner
             }
 
             $sql = file_get_contents($file);
-            if ($sql === false) {
-                throw new \Exception("Cannot read migration file: {$file}");
-            }
+            if ($sql === false) { // @codeCoverageIgnore
+                throw new \Exception("Cannot read migration file: {$file}"); // @codeCoverageIgnore
+            } // @codeCoverageIgnore
 
             try {
                 $pdo->exec($sql);
@@ -94,9 +94,9 @@ class MigrationRunner
             }
 
             $sql = file_get_contents($down);
-            if ($sql === false) {
-                throw new \Exception("Cannot read rollback file: {$down}");
-            }
+            if ($sql === false) { // @codeCoverageIgnore
+                throw new \Exception("Cannot read rollback file: {$down}"); // @codeCoverageIgnore
+            } // @codeCoverageIgnore
 
             try {
                 $pdo->exec($sql);

--- a/src/Generator/Builder/ControllerBuilder.php
+++ b/src/Generator/Builder/ControllerBuilder.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace EntityForge\Generator\Builder;
+
+class ControllerBuilder
+{
+    public function build(string $name): string
+    {
+        return <<<PHP
+<?php
+
+namespace App\Http\Controller;
+
+use EntityForge\Http\Request;
+use EntityForge\Http\Response;
+
+class {$name}
+{
+    public function index(Request \$request): Response
+    {
+        return (new Response())->withJson([]);
+    }
+
+    public function show(Request \$request): Response
+    {
+        \$id = (int) \$request->param('id');
+        return (new Response())->withJson([]);
+    }
+
+    public function store(Request \$request): Response
+    {
+        return (new Response())->withJson([], 201);
+    }
+
+    public function update(Request \$request): Response
+    {
+        \$id = (int) \$request->param('id');
+        return (new Response())->withJson([]);
+    }
+
+    public function destroy(Request \$request): Response
+    {
+        \$id = (int) \$request->param('id');
+        return (new Response())->withJson(['deleted' => true]);
+    }
+}
+PHP;
+    }
+}

--- a/src/Generator/Builder/EntityBuilder.php
+++ b/src/Generator/Builder/EntityBuilder.php
@@ -11,25 +11,23 @@ class EntityBuilder
         $fields = $schema->getFields();
 
         $properties = '';
-
         foreach ($fields as $name => $type) {
             $properties .= "    public {$this->mapType($type)} \${$name};\n";
         }
 
-        //Get Relations
         $relationsCode = $this->buildRelations($schema);
+        $useBlock = $this->buildUseStatements($schema);
+
+        $body = $properties . ($relationsCode !== '' ? "\n{$relationsCode}" : '');
 
         return <<<PHP
 <?php
 
 namespace App\Entity;
-
+{$useBlock}
 class {$className}
 {
-{$properties}
-
-{$relationsCode}
-
+{$body}
 }
 PHP;
     }
@@ -43,32 +41,67 @@ PHP;
         };
     }
 
+    private function buildUseStatements(EntitySchema $schema): string
+    {
+        $relations = $schema->getRelations();
+        $entities = [];
+
+        /** @var array<string, string> $belongsTo */
+        $belongsTo = $relations['belongsTo'] ?? [];
+        /** @var array<string, string> $hasMany */
+        $hasMany = $relations['hasMany'] ?? [];
+
+        foreach (array_keys($belongsTo) as $entity) {
+            $entities[] = (string) $entity;
+        }
+        foreach (array_keys($hasMany) as $entity) {
+            $entities[] = (string) $entity;
+        }
+
+        if (empty($entities)) {
+            return "\n";
+        }
+
+        $lines = "\n";
+        foreach (array_unique($entities) as $entity) {
+            $lines .= "use App\\Entity\\{$entity};\n";
+        }
+
+        return $lines . "\n";
+    }
+
     private function buildRelations(EntitySchema $schema): string
     {
         $relations = $schema->getRelations();
         $code = '';
 
-        // belongsTo
-        foreach ($relations['belongsTo'] ?? [] as $entity => $foreignKey) {
-            $method = lcfirst($entity);
-            $code .= "
-            public function {$method}(): string
-                {
-                return '{$entity} via {$foreignKey}';
-                }
-                ";
+        /** @var array<string, string> $belongsTo */
+        $belongsTo = $relations['belongsTo'] ?? [];
+        foreach ($belongsTo as $entity => $foreignKey) {
+            $property = lcfirst((string) $entity);
+            $code .= "    /** Loaded via {$foreignKey} */\n";
+            $code .= "    public ?{$entity} \${$property} = null;\n";
         }
 
-        // hasMany
-        foreach ($relations['hasMany'] ?? [] as $entity => $foreignKey) {
-            $method = lcfirst($entity) . 's';
-            $code .= "
-        public function {$method}(): string
-            {
-            return '{$entity} list via {$foreignKey}';
-            }";
+        /** @var array<string, string> $hasMany */
+        $hasMany = $relations['hasMany'] ?? [];
+        foreach ($hasMany as $entity => $foreignKey) {
+            $property = $this->pluralize(lcfirst((string) $entity));
+            $code .= "    /** @var {$entity}[] Loaded via {$foreignKey} */\n";
+            $code .= "    public array \${$property} = [];\n";
         }
 
         return $code;
+    }
+
+    private function pluralize(string $word): string
+    {
+        if (str_ends_with($word, 'y') && !preg_match('/[aeiou]y$/i', $word)) {
+            return substr($word, 0, -1) . 'ies';
+        }
+        if (preg_match('/(s|x|z|ch|sh)$/', $word)) {
+            return $word . 'es';
+        }
+        return $word . 's';
     }
 }

--- a/src/Generator/Builder/EntityBuilder.php
+++ b/src/Generator/Builder/EntityBuilder.php
@@ -35,9 +35,11 @@ PHP;
     private function mapType(string $type): string
     {
         return match ($type) {
-            'int' => 'int',
-            'string' => 'string',
-            default => 'mixed'
+            'int'                    => 'int',
+            'float'                  => 'float',
+            'bool'                   => 'bool',
+            'string', 'text', 'datetime' => 'string',
+            default                  => 'mixed',
         };
     }
 

--- a/src/Generator/Builder/MiddlewareBuilder.php
+++ b/src/Generator/Builder/MiddlewareBuilder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace EntityForge\Generator\Builder;
+
+class MiddlewareBuilder
+{
+    public function build(string $name): string
+    {
+        return <<<PHP
+<?php
+
+namespace App\Http\Middleware;
+
+use EntityForge\Http\Middleware\MiddlewareInterface;
+use EntityForge\Http\Request;
+use EntityForge\Http\Response;
+
+class {$name} implements MiddlewareInterface
+{
+    public function handle(Request \$request, callable \$next): Response
+    {
+        return \$next(\$request);
+    }
+}
+PHP;
+    }
+}

--- a/src/Generator/Builder/MiddlewareBuilder.php
+++ b/src/Generator/Builder/MiddlewareBuilder.php
@@ -24,4 +24,37 @@ class {$name} implements MiddlewareInterface
 }
 PHP;
     }
+
+    public function buildAuth(string $name): string
+    {
+        return <<<PHP
+<?php
+
+namespace App\Http\Middleware;
+
+use EntityForge\Http\Middleware\AuthMiddlewareInterface;
+use EntityForge\Http\Request;
+use EntityForge\Http\Response;
+
+class {$name} implements AuthMiddlewareInterface
+{
+    public function handle(Request \$request, callable \$next): Response
+    {
+        // 1. Extract credentials from the request (e.g. Bearer token, session, API key).
+        //    \$token = \$request->header('Authorization');
+
+        // 2. Verify the credentials with your auth provider (Firebase, Auth0, custom JWT, etc.).
+        //    \$user = \$this->authProvider->verify(\$token);
+
+        // 3. Attach the resolved identity to the request and pass it downstream.
+        //    return \$next(\$request->withAttribute('user', \$user));
+
+        // 4. On failure, return an early response without calling \$next.
+        //    return (new Response())->withStatus(401)->withJson(['error' => 'Unauthorized']);
+
+        return \$next(\$request);
+    }
+}
+PHP;
+    }
 }

--- a/src/Generator/EntityGenerator.php
+++ b/src/Generator/EntityGenerator.php
@@ -30,6 +30,7 @@ class EntityGenerator
     }
 
     /**
+     * @param array<string, mixed> $config
      * @param array<string, string> $pkMap  entity name → primary key column for FK resolution
      */
     public function generate(array $config, bool $withMigration = false, array $pkMap = []): void

--- a/src/Generator/Schema/EntitySchema.php
+++ b/src/Generator/Schema/EntitySchema.php
@@ -4,8 +4,10 @@ namespace EntityForge\Generator\Schema;
 
 class EntitySchema
 {
+    /** @var array<string, mixed> */
     private array $config;
 
+    /** @param array<string, mixed> $config */
     public function __construct(array $config)
     {
         $this->config = $config;
@@ -39,7 +41,8 @@ class EntitySchema
         return null;
     }
 
-public function getFields(): array
+    /** @return array<string, string> */
+    public function getFields(): array
     {
         $fields = $this->config['fields'] ?? [];
 
@@ -56,11 +59,13 @@ public function getFields(): array
         return $fields;
     }
 
+    /** @return array<string, mixed> */
     public function getRelations(): array
     {
         return $this->config['relations'] ?? [];
     }
 
+    /** @return array<int, mixed> */
     public function getIndexes(): array
     {
         return $this->config['indexes'] ?? [];

--- a/src/Generator/Schema/SchemaValidator.php
+++ b/src/Generator/Schema/SchemaValidator.php
@@ -28,7 +28,7 @@ class SchemaValidator
                 throw new \InvalidArgumentException("Invalid field name: {$field}");
             }
 
-            if (!in_array($type, ['int', 'string', 'float', 'bool'], true)) {
+            if (!in_array($type, ['int', 'string', 'float', 'bool', 'text', 'datetime'], true)) {
                 throw new \InvalidArgumentException("Unsupported field type: {$type} for {$field}");
             }
         }

--- a/src/Generator/Schema/SchemaValidator.php
+++ b/src/Generator/Schema/SchemaValidator.php
@@ -4,6 +4,7 @@ namespace EntityForge\Generator\Schema;
 
 class SchemaValidator
 {
+    /** @param array<string, mixed> $config */
     public function validate(array $config): void
     {
         // Entity name is required

--- a/src/Http/Middleware/AuthMiddlewareInterface.php
+++ b/src/Http/Middleware/AuthMiddlewareInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace EntityForge\Http\Middleware;
+
+/**
+ * Marker interface for auth middleware.
+ *
+ * Implementations must authenticate the request and attach the resolved
+ * identity to it before passing it downstream:
+ *
+ *   return $next($request->withAttribute('user', $user));
+ *
+ * Downstream handlers retrieve the identity via:
+ *
+ *   $user = $request->getAttribute('user');
+ */
+interface AuthMiddlewareInterface extends MiddlewareInterface {}

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -9,6 +9,7 @@ class Request
      * @param array<string, mixed> $query
      * @param array<string, mixed> $body
      * @param array<string, string> $params
+     * @param array<string, mixed> $attributes
      */
     public function __construct(
         private array $headers = [],
@@ -16,7 +17,8 @@ class Request
         private array $body = [],
         private string $method = 'GET',
         private string $path = '/',
-        private array $params = []
+        private array $params = [],
+        private array $attributes = []
     ) {}
 
     public static function capture(): self
@@ -76,5 +78,17 @@ class Request
         $clone = clone $this;
         $clone->params = $params;
         return $clone;
+    }
+
+    public function withAttribute(string $key, mixed $value): self
+    {
+        $clone = clone $this;
+        $clone->attributes[$key] = $value;
+        return $clone;
+    }
+
+    public function getAttribute(string $key, mixed $default = null): mixed
+    {
+        return $this->attributes[$key] ?? $default;
     }
 }

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -4,23 +4,29 @@ namespace EntityForge\Http;
 
 class Request
 {
-
+    /**
+     * @param array<string, string> $headers
+     * @param array<string, mixed> $query
+     * @param array<string, mixed> $body
+     * @param array<string, string> $params
+     */
     public function __construct(
         private array $headers = [],
         private array $query = [],
         private array $body = [],
-        private array|string $method = 'GET',
+        private string $method = 'GET',
         private string $path = '/',
         private array $params = []
     ) {}
 
     public static function capture(): self
     {
-        $uri = $_SERVER['REQUEST_URI'] ?? '/';
-        $path = parse_url($uri, PHP_URL_PATH) ?? '/';
+        $uri    = $_SERVER['REQUEST_URI'] ?? '/';
+        $parsed = parse_url($uri, PHP_URL_PATH);
+        $path   = is_string($parsed) ? $parsed : '/';
 
         return new self(
-            headers: getallheaders(),
+            headers: getallheaders() ?: [],
             query: $_GET,
             body: $_POST,
             method: $_SERVER['REQUEST_METHOD'] ?? 'GET',
@@ -58,11 +64,13 @@ class Request
         return $this->params[$name] ?? null;
     }
 
+    /** @return array<string, string> */
     public function params(): array
     {
         return $this->params;
     }
 
+    /** @param array<string, string> $params */
     public function withParams(array $params): self
     {
         $clone = clone $this;

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -6,8 +6,10 @@ class Response
 {
     private int $status = 200;
     private string $body = '';
+    /** @var array<string, string> */
     private array $headers = [];
 
+    /** @param array<string, mixed> $data */
     public function withJson(array $data, int $status = 200): self
     {
         $clone = clone $this;
@@ -41,6 +43,7 @@ class Response
         return $this->body;
     }
 
+    /** @return array<string, string> */
     public function getHeaders(): array
     {
         return $this->headers;
@@ -64,6 +67,7 @@ class Response
         $body();
     }
 
+    /** @param array<string, mixed> $data */
     public function json(array $data, int $status = 200): void
     {
         http_response_code($status);

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -8,6 +8,7 @@ use function FastRoute\simpleDispatcher;
 
 class Router
 {
+    /** @var array<int, array{string, string, callable}> */
     private array $routes = [];
 
     public function get(string $path, callable $handler): self

--- a/src/Repository/BaseRepository.php
+++ b/src/Repository/BaseRepository.php
@@ -13,8 +13,10 @@ abstract class BaseRepository
 {
     protected Connection $connection;
     protected string $table;
+    /** @var array<string, mixed> */
     protected array $config;
 
+    /** @param array<string, mixed> $config */
     public function __construct(array $config)
     {
         $this->config = $config;
@@ -44,12 +46,12 @@ abstract class BaseRepository
     protected function getTenantId(): string
     {
         TenantGuard::ensureTenant();
-        return TenantContext::getTenantId();
+        return TenantContext::getTenantId() ?? throw new \LogicException('Tenant ID is null after guard check.');
     }
 
     /**
-     * Apply tenant scope only for shared strategy
-     *
+     * @param array<string, mixed> $data
+     * @return array<string, mixed>
      * @throws Exception
      */
     protected function applyTenantScope(array $data): array
@@ -71,8 +73,8 @@ abstract class BaseRepository
     }
 
     /**
-     * Insert record
-     *
+     * @param array<string, mixed> $data
+     * @return array<string, mixed>
      * @throws Exception
      */
     public function create(array $data): array
@@ -105,8 +107,7 @@ abstract class BaseRepository
     }
 
     /**
-     * Fetch all records
-     *
+     * @return array<int, array<string, mixed>>
      * @throws Exception
      */
     public function findAll(): array
@@ -131,8 +132,7 @@ abstract class BaseRepository
     }
 
     /**
-     * Find record by ID
-     *
+     * @return array<string, mixed>|null
      * @throws Exception
      */
     public function findById(int $id): ?array
@@ -161,8 +161,8 @@ abstract class BaseRepository
     }
 
     /**
-     * Find records by conditions
-     *
+     * @param array<string, mixed> $conditions
+     * @return array<int, array<string, mixed>>
      * @throws Exception
      */
     public function where(array $conditions): array
@@ -199,15 +199,14 @@ abstract class BaseRepository
     }
 
     /**
-     * Update record by ID
-     *
+     * @param array<string, mixed> $data
      * @throws Exception
      */
     public function update(int $id, array $data): bool
     {
         $setClauses = [];
 
-        foreach ($data as $column => $value) {
+        foreach (array_keys($data) as $column) {
             $this->assertColumnName($column);
             $setClauses[] = "{$column} = :{$column}";
         }

--- a/src/Tenant/Resolver/HeaderTenantResolver.php
+++ b/src/Tenant/Resolver/HeaderTenantResolver.php
@@ -16,6 +16,7 @@ class HeaderTenantResolver implements TenantResolverInterface
     }
 
     /**
+     * @param array<string, mixed> $context
      * @throws Exception
      */
     public function resolve(array $context): string

--- a/src/Tenant/Resolver/JwtTenantResolver.php
+++ b/src/Tenant/Resolver/JwtTenantResolver.php
@@ -16,6 +16,7 @@ class JwtTenantResolver implements TenantResolverInterface
     ) {}
 
     /**
+     * @param array<string, mixed> $context
      * @throws Exception
      */
     public function resolve(array $context): string

--- a/src/Tenant/Resolver/SessionTenantResolver.php
+++ b/src/Tenant/Resolver/SessionTenantResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace EntityForge\Tenant\Resolver;
+
+use EntityForge\Tenant\TenantResolverInterface;
+use Exception;
+
+class SessionTenantResolver implements TenantResolverInterface
+{
+    public function __construct(private string $sessionKey = 'tenant_id') {}
+
+    /**
+     * @param array<string, mixed> $context
+     * @throws Exception
+     */
+    public function resolve(array $context): string
+    {
+        // Accept session data injected via context (testable) or fall back to $_SESSION
+        if (isset($context['session'])) {
+            /** @var array<string, mixed> $session */
+            $session = $context['session'];
+            if (!isset($session[$this->sessionKey]) || $session[$this->sessionKey] === '') {
+                throw new Exception("Tenant key '{$this->sessionKey}' not found in session.");
+            }
+            return (string) $session[$this->sessionKey];
+        }
+
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+
+        if (!isset($_SESSION[$this->sessionKey]) || $_SESSION[$this->sessionKey] === '') {
+            throw new Exception("Tenant key '{$this->sessionKey}' not found in session.");
+        }
+
+        return (string) $_SESSION[$this->sessionKey];
+    }
+}

--- a/src/Tenant/Resolver/SubdomainTenantResolver.php
+++ b/src/Tenant/Resolver/SubdomainTenantResolver.php
@@ -13,6 +13,7 @@ class SubdomainTenantResolver implements TenantResolverInterface
     ) {}
 
     /**
+     * @param array<string, mixed> $context
      * @throws Exception
      */
     public function resolve(array $context): string

--- a/src/Tenant/TenantConnectionResolver.php
+++ b/src/Tenant/TenantConnectionResolver.php
@@ -7,9 +7,11 @@ use Exception;
 
 class TenantConnectionResolver
 {
+    /** @var array<string, Connection> */
     private static array $connections = [];
 
     /**
+     * @param array<string, mixed> $config
      * @throws Exception
      */
     public static function resolve(array $config): Connection

--- a/src/Tenant/TenantProvisioner.php
+++ b/src/Tenant/TenantProvisioner.php
@@ -7,6 +7,7 @@ use EntityForge\Database\MigrationRunner;
 
 class TenantProvisioner
 {
+    /** @param array<string, mixed> $config */
     public function __construct(private array $config) {}
 
     public function create(string $tenantId): void
@@ -36,6 +37,7 @@ class TenantProvisioner
         $this->dropDatabase($dbConfig, $dbName);
     }
 
+    /** @param array<string, mixed> $config */
     protected function getRootPdo(array $config): \PDO
     {
         $dsn = sprintf('%s:host=%s;port=%s', $config['driver'], $config['host'], $config['port']);
@@ -47,11 +49,13 @@ class TenantProvisioner
         );
     }
 
+    /** @param array<string, mixed> $config */
     private function createDatabase(array $config, string $dbName): void
     {
         $this->getRootPdo($config)->exec("CREATE DATABASE IF NOT EXISTS {$dbName}");
     }
 
+    /** @param array<string, mixed> $config */
     private function dropDatabase(array $config, string $dbName): void
     {
         $this->getRootPdo($config)->exec("DROP DATABASE IF EXISTS {$dbName}");

--- a/src/Tenant/TenantRepository.php
+++ b/src/Tenant/TenantRepository.php
@@ -10,6 +10,7 @@ class TenantRepository
     private Connection $connection;
 
     /**
+     * @param array<string, mixed> $config
      * @throws Exception
      */
     public function __construct(array $config)
@@ -28,13 +29,20 @@ class TenantRepository
         ]);
     }
 
+    /**
+     * @return array<int, array<string, mixed>>
+     * @throws \Exception
+     */
     public function all(): array
     {
-        return $this->connection->getPdo()
-            ->query("SELECT * FROM tenants")
-            ->fetchAll(\PDO::FETCH_ASSOC);
+        $stmt = $this->connection->getPdo()->query("SELECT * FROM tenants");
+        if ($stmt === false) {
+            throw new \Exception("Failed to query tenants.");
+        }
+        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
     }
 
+    /** @return array<int, array<string, mixed>> */
     public function allActive(): array
     {
         $stmt = $this->connection->getPdo()->prepare(
@@ -55,6 +63,7 @@ class TenantRepository
         return (int) $stmt->fetchColumn() > 0;
     }
 
+    /** @return array<string, mixed>|null */
     public function findByTenantId(string $tenantId): ?array
     {
         $stmt = $this->connection->getPdo()->prepare(

--- a/src/Tenant/TenantResolverFactory.php
+++ b/src/Tenant/TenantResolverFactory.php
@@ -4,6 +4,7 @@ namespace EntityForge\Tenant;
 
 use EntityForge\Tenant\Resolver\HeaderTenantResolver;
 use EntityForge\Tenant\Resolver\JwtTenantResolver;
+use EntityForge\Tenant\Resolver\SessionTenantResolver;
 use EntityForge\Tenant\Resolver\SubdomainTenantResolver;
 use Exception;
 
@@ -28,6 +29,9 @@ class TenantResolverFactory
                 $config['tenancy']['jwt_public_key'] ?? '',
                 $config['tenancy']['jwt_algorithm']  ?? 'RS256',
                 $config['tenancy']['jwt_tenant_claim'] ?? 'tenant_id'
+            ),
+            'session' => new SessionTenantResolver(
+                $config['tenancy']['session_key'] ?? 'tenant_id'
             ),
             default => throw new Exception("Unsupported tenant resolver type: {$resolverType}"),
         };

--- a/src/Tenant/TenantResolverFactory.php
+++ b/src/Tenant/TenantResolverFactory.php
@@ -10,6 +10,7 @@ use Exception;
 class TenantResolverFactory
 {
     /**
+     * @param array<string, mixed> $config
      * @throws Exception
      */
     public static function create(array $config): TenantResolverInterface

--- a/src/Tenant/TenantResolverInterface.php
+++ b/src/Tenant/TenantResolverInterface.php
@@ -4,5 +4,6 @@ namespace EntityForge\Tenant;
 
 interface TenantResolverInterface
 {
+    /** @param array<string, mixed> $context */
     public function resolve(array $context): string;
 }

--- a/src/Tenant/TenantService.php
+++ b/src/Tenant/TenantService.php
@@ -6,8 +6,10 @@ class TenantService
 {
     private TenantRepository $repo;
     private TenantProvisioner $provisioner;
+    /** @var array<string, mixed> */
     private array $config;
 
+    /** @param array<string, mixed> $config */
     public function __construct(
         array $config,
         ?TenantRepository $repo = null,

--- a/tests/Console/ConsoleCommandsTest.php
+++ b/tests/Console/ConsoleCommandsTest.php
@@ -124,6 +124,56 @@ class ConsoleCommandsTest extends TestCase
         $this->assertStringContainsString('No entity configs found', $tester->getDisplay());
     }
 
+    public function test_generate_all_skips_cross_batch_dependency(): void
+    {
+        $tmp = sys_get_temp_dir() . '/ef_con_' . uniqid();
+        mkdir($tmp . '/config/entities', 0755, true);
+        // Post references ExternalUser which is NOT in the batch — the sort should skip it
+        file_put_contents($tmp . '/config/entities/Post.json', json_encode([
+            'entity' => 'Post',
+            'fields' => ['id' => 'int', 'external_user_id' => 'int'],
+            'relations' => ['belongsTo' => ['ExternalUser' => 'external_user_id']],
+        ]));
+        $origDir = getcwd();
+        chdir($tmp);
+
+        $tester = new CommandTester(new GenerateAllCommand());
+        $code = $tester->execute([]);
+
+        chdir($origDir);
+        $this->removeDir($tmp);
+
+        $this->assertSame(0, $code);
+        $this->assertStringContainsString('Generated Post', $tester->getDisplay());
+    }
+
+    public function test_generate_all_fails_on_circular_dependency(): void
+    {
+        $tmp = sys_get_temp_dir() . '/ef_con_' . uniqid();
+        mkdir($tmp . '/config/entities', 0755, true);
+        file_put_contents($tmp . '/config/entities/Alpha.json', json_encode([
+            'entity' => 'Alpha',
+            'fields' => ['id' => 'int'],
+            'relations' => ['belongsTo' => ['Beta' => 'beta_id']],
+        ]));
+        file_put_contents($tmp . '/config/entities/Beta.json', json_encode([
+            'entity' => 'Beta',
+            'fields' => ['id' => 'int'],
+            'relations' => ['belongsTo' => ['Alpha' => 'alpha_id']],
+        ]));
+        $origDir = getcwd();
+        chdir($tmp);
+
+        $tester = new CommandTester(new GenerateAllCommand());
+        $code = $tester->execute([]);
+
+        chdir($origDir);
+        $this->removeDir($tmp);
+
+        $this->assertSame(1, $code);
+        $this->assertStringContainsString('Circular dependency', $tester->getDisplay());
+    }
+
     public function test_generate_all_generates_all_entities(): void
     {
         $tmp = sys_get_temp_dir() . '/ef_con_' . uniqid();

--- a/tests/Console/MakeCommandsTest.php
+++ b/tests/Console/MakeCommandsTest.php
@@ -67,6 +67,21 @@ class MakeCommandsTest extends TestCase
         $this->assertStringContainsString('Invalid middleware name', $tester->getDisplay());
     }
 
+    public function test_make_middleware_auth_flag_implements_auth_interface(): void
+    {
+        $tester = new CommandTester(new MakeMiddlewareCommand());
+        $tester->execute([
+            'name'     => 'FirebaseAuthMiddleware',
+            '--output' => $this->tmp,
+            '--auth'   => true,
+        ]);
+
+        $content = file_get_contents($this->tmp . '/FirebaseAuthMiddleware.php');
+        $this->assertStringContainsString('implements AuthMiddlewareInterface', $content);
+        $this->assertStringContainsString('use EntityForge\Http\Middleware\AuthMiddlewareInterface', $content);
+        $this->assertStringContainsString('withAttribute', $content);
+    }
+
     // ── make:controller ────────────────────────────────────────────────────────
 
     public function test_make_controller_command_name(): void

--- a/tests/Console/MakeCommandsTest.php
+++ b/tests/Console/MakeCommandsTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Console;
+
+use EntityForge\Console\MakeControllerCommand;
+use EntityForge\Console\MakeMiddlewareCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class MakeCommandsTest extends TestCase
+{
+    private string $tmp;
+
+    protected function setUp(): void
+    {
+        $this->tmp = sys_get_temp_dir() . '/ef_make_' . uniqid();
+        mkdir($this->tmp, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->tmp);
+    }
+
+    // ── make:middleware ────────────────────────────────────────────────────────
+
+    public function test_make_middleware_command_name(): void
+    {
+        $this->assertSame('make:middleware', (new MakeMiddlewareCommand())->getName());
+    }
+
+    public function test_make_middleware_generates_file(): void
+    {
+        $tester = new CommandTester(new MakeMiddlewareCommand());
+        $code = $tester->execute([
+            'name'     => 'AuthMiddleware',
+            '--output' => $this->tmp,
+        ]);
+
+        $this->assertSame(0, $code);
+        $this->assertFileExists($this->tmp . '/AuthMiddleware.php');
+    }
+
+    public function test_make_middleware_output_contains_correct_class(): void
+    {
+        $tester = new CommandTester(new MakeMiddlewareCommand());
+        $tester->execute([
+            'name'     => 'AuthMiddleware',
+            '--output' => $this->tmp,
+        ]);
+
+        $content = file_get_contents($this->tmp . '/AuthMiddleware.php');
+        $this->assertStringContainsString('class AuthMiddleware', $content);
+        $this->assertStringContainsString('implements MiddlewareInterface', $content);
+        $this->assertStringContainsString('public function handle(Request $request, callable $next): Response', $content);
+    }
+
+    public function test_make_middleware_fails_on_invalid_name(): void
+    {
+        $tester = new CommandTester(new MakeMiddlewareCommand());
+        $code = $tester->execute([
+            'name'     => 'invalid-name',
+            '--output' => $this->tmp,
+        ]);
+
+        $this->assertSame(1, $code);
+        $this->assertStringContainsString('Invalid middleware name', $tester->getDisplay());
+    }
+
+    // ── make:controller ────────────────────────────────────────────────────────
+
+    public function test_make_controller_command_name(): void
+    {
+        $this->assertSame('make:controller', (new MakeControllerCommand())->getName());
+    }
+
+    public function test_make_controller_generates_file(): void
+    {
+        $tester = new CommandTester(new MakeControllerCommand());
+        $code = $tester->execute([
+            'name'     => 'UserController',
+            '--output' => $this->tmp,
+        ]);
+
+        $this->assertSame(0, $code);
+        $this->assertFileExists($this->tmp . '/UserController.php');
+    }
+
+    public function test_make_controller_output_contains_crud_stubs(): void
+    {
+        $tester = new CommandTester(new MakeControllerCommand());
+        $tester->execute([
+            'name'     => 'UserController',
+            '--output' => $this->tmp,
+        ]);
+
+        $content = file_get_contents($this->tmp . '/UserController.php');
+        $this->assertStringContainsString('class UserController', $content);
+        $this->assertStringContainsString('public function index(', $content);
+        $this->assertStringContainsString('public function show(', $content);
+        $this->assertStringContainsString('public function store(', $content);
+        $this->assertStringContainsString('public function update(', $content);
+        $this->assertStringContainsString('public function destroy(', $content);
+    }
+
+    public function test_make_controller_fails_on_invalid_name(): void
+    {
+        $tester = new CommandTester(new MakeControllerCommand());
+        $code = $tester->execute([
+            'name'     => '123Bad',
+            '--output' => $this->tmp,
+        ]);
+
+        $this->assertSame(1, $code);
+        $this->assertStringContainsString('Invalid controller name', $tester->getDisplay());
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (glob($dir . '/*') ?: [] as $item) {
+            is_dir($item) ? $this->removeDir($item) : unlink($item);
+        }
+        rmdir($dir);
+    }
+}

--- a/tests/Database/MigrationRunnerTest.php
+++ b/tests/Database/MigrationRunnerTest.php
@@ -272,6 +272,49 @@ class MigrationRunnerTest extends TestCase
         $this->runner->rollback($this->tmpDir);
     }
 
+    public function test_run_throws_when_show_columns_returns_false(): void
+    {
+        $this->pdo->allows('exec')->with(Mockery::pattern('/CREATE TABLE IF NOT EXISTS migrations/'))->once();
+
+        $this->pdo->allows('query')->with("SHOW COLUMNS FROM migrations LIKE 'batch'")->andReturn(false);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches('/Failed to check migrations table schema/');
+
+        $this->runner->run($this->tmpDir);
+    }
+
+    public function test_run_throws_when_select_migration_returns_false(): void
+    {
+        file_put_contents($this->tmpDir . '/0001_create_users.up.sql', 'CREATE TABLE users (id INT);');
+
+        $this->pdo->allows('exec')->with(Mockery::pattern('/CREATE TABLE IF NOT EXISTS migrations/'))->once();
+
+        $colStmt = Mockery::mock(PDOStatement::class);
+        $colStmt->allows('fetch')->andReturn(['Field' => 'batch']);
+        $this->pdo->allows('query')->with("SHOW COLUMNS FROM migrations LIKE 'batch'")->andReturn($colStmt);
+
+        $this->pdo->allows('query')->with('SELECT migration FROM migrations')->andReturn(false);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches('/Failed to query migrations table/');
+
+        $this->runner->run($this->tmpDir);
+    }
+
+    public function test_dry_run_handles_database_error_gracefully(): void
+    {
+        file_put_contents($this->tmpDir . '/0001_create_users.up.sql', 'CREATE TABLE users (id INT);');
+
+        // getExecutedSafe catches when SELECT returns false, falls back to []
+        $this->pdo->allows('query')->with('SELECT migration FROM migrations')->andReturn(false);
+        $this->pdo->shouldNotReceive('exec');
+
+        $this->expectOutputRegex('/\[DRY RUN\] Would execute: 0001_create_users\.up\.sql/');
+
+        $this->runner->run($this->tmpDir, true);
+    }
+
     public function test_rollback_throws_on_sql_failure(): void
     {
         $migration = '0001_fail.up.sql';

--- a/tests/Generator/Builder/EntityBuilderTest.php
+++ b/tests/Generator/Builder/EntityBuilderTest.php
@@ -64,7 +64,7 @@ class EntityBuilderTest extends TestCase
         $this->assertStringContainsString('public mixed $data', $code);
     }
 
-    public function test_generates_belongs_to_relation_method(): void
+    public function test_generates_belongs_to_relation_property(): void
     {
         $code = $this->builder->build($this->schema([
             'entity' => 'Order',
@@ -72,11 +72,12 @@ class EntityBuilderTest extends TestCase
             'relations' => ['belongsTo' => ['User' => 'user_id']],
         ]));
 
-        $this->assertStringContainsString('function user()', $code);
-        $this->assertStringContainsString('User via user_id', $code);
+        $this->assertStringContainsString('public ?User $user = null', $code);
+        $this->assertStringContainsString('Loaded via user_id', $code);
+        $this->assertStringContainsString('use App\Entity\User', $code);
     }
 
-    public function test_generates_has_many_relation_method(): void
+    public function test_generates_has_many_relation_property(): void
     {
         $code = $this->builder->build($this->schema([
             'entity' => 'User',
@@ -84,8 +85,10 @@ class EntityBuilderTest extends TestCase
             'relations' => ['hasMany' => ['Order' => 'user_id']],
         ]));
 
-        $this->assertStringContainsString('function orders()', $code);
-        $this->assertStringContainsString('Order list via user_id', $code);
+        $this->assertStringContainsString('public array $orders = []', $code);
+        $this->assertStringContainsString('@var Order[]', $code);
+        $this->assertStringContainsString('Loaded via user_id', $code);
+        $this->assertStringContainsString('use App\Entity\Order', $code);
     }
 
     public function test_generates_valid_php_opening(): void

--- a/tests/Generator/Builder/EntityBuilderTest.php
+++ b/tests/Generator/Builder/EntityBuilderTest.php
@@ -131,6 +131,28 @@ class EntityBuilderTest extends TestCase
         $this->assertStringContainsString('use App\Entity\Order', $code);
     }
 
+    public function test_pluralizes_consonant_y_to_ies(): void
+    {
+        $code = $this->builder->build($this->schema([
+            'entity' => 'User',
+            'fields' => [],
+            'relations' => ['hasMany' => ['Category' => 'user_id']],
+        ]));
+
+        $this->assertStringContainsString('public array $categories = []', $code);
+    }
+
+    public function test_pluralizes_sibilant_ending_to_es(): void
+    {
+        $code = $this->builder->build($this->schema([
+            'entity' => 'User',
+            'fields' => [],
+            'relations' => ['hasMany' => ['Bus' => 'user_id']],
+        ]));
+
+        $this->assertStringContainsString('public array $buses = []', $code);
+    }
+
     public function test_generates_valid_php_opening(): void
     {
         $code = $this->builder->build($this->schema(['entity' => 'Foo', 'fields' => []]));

--- a/tests/Generator/Builder/EntityBuilderTest.php
+++ b/tests/Generator/Builder/EntityBuilderTest.php
@@ -54,11 +54,51 @@ class EntityBuilderTest extends TestCase
         $this->assertStringContainsString('public string $name', $code);
     }
 
+    public function test_float_type_maps_to_float(): void
+    {
+        $code = $this->builder->build($this->schema([
+            'entity' => 'Product',
+            'fields' => ['price' => 'float'],
+        ]));
+
+        $this->assertStringContainsString('public float $price', $code);
+    }
+
+    public function test_bool_type_maps_to_bool(): void
+    {
+        $code = $this->builder->build($this->schema([
+            'entity' => 'Product',
+            'fields' => ['active' => 'bool'],
+        ]));
+
+        $this->assertStringContainsString('public bool $active', $code);
+    }
+
+    public function test_text_type_maps_to_string(): void
+    {
+        $code = $this->builder->build($this->schema([
+            'entity' => 'Post',
+            'fields' => ['body' => 'text'],
+        ]));
+
+        $this->assertStringContainsString('public string $body', $code);
+    }
+
+    public function test_datetime_type_maps_to_string(): void
+    {
+        $code = $this->builder->build($this->schema([
+            'entity' => 'Event',
+            'fields' => ['starts_at' => 'datetime'],
+        ]));
+
+        $this->assertStringContainsString('public string $starts_at', $code);
+    }
+
     public function test_unknown_type_maps_to_mixed(): void
     {
         $code = $this->builder->build($this->schema([
             'entity' => 'Blob',
-            'fields' => ['data' => 'float'],
+            'fields' => ['data' => 'json'],
         ]));
 
         $this->assertStringContainsString('public mixed $data', $code);

--- a/tests/Generator/Schema/SchemaValidatorTest.php
+++ b/tests/Generator/Schema/SchemaValidatorTest.php
@@ -80,10 +80,12 @@ class SchemaValidatorTest extends TestCase
         $this->validator->validate([
             'entity' => 'Product',
             'fields' => [
-                'id'     => 'int',
-                'name'   => 'string',
-                'price'  => 'float',
-                'active' => 'bool',
+                'id'         => 'int',
+                'name'       => 'string',
+                'price'      => 'float',
+                'active'     => 'bool',
+                'body'       => 'text',
+                'created_at' => 'datetime',
             ],
         ]);
         $this->assertTrue(true);

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -94,25 +94,37 @@ class RequestTest extends TestCase
         $this->assertSame([], $original->params());
     }
 
-    public function test_capture_skipped_outside_web_sapi(): void
+    public function test_capture_reads_superglobals(): void
     {
-        if (!function_exists('getallheaders')) {
-            $this->markTestSkipped('getallheaders() not available outside web SAPI');
-        }
-
         $_SERVER['REQUEST_METHOD'] = 'PUT';
+        $_SERVER['REQUEST_URI']    = '/api/items';
         $_GET  = ['q' => 'search'];
         $_POST = ['name' => 'Alice'];
 
         $request = Request::capture();
 
         $this->assertSame('PUT', $request->method());
+        $this->assertSame('/api/items', $request->path());
         $this->assertSame('search', $request->query('q'));
         $this->assertSame('Alice', $request->body('name'));
 
         $_SERVER['REQUEST_METHOD'] = 'GET';
+        unset($_SERVER['REQUEST_URI']);
         $_GET = [];
         $_POST = [];
+    }
+
+    public function test_capture_defaults_path_when_uri_has_no_path(): void
+    {
+        $_SERVER['REQUEST_URI'] = 'http://example.com';
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        $request = Request::capture();
+
+        // parse_url of a scheme-only URI returns null for PHP_URL_PATH → falls back to '/'
+        $this->assertIsString($request->path());
+
+        unset($_SERVER['REQUEST_URI']);
     }
 
     // ── Attributes ─────────────────────────────────────────────────────────────

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -114,4 +114,48 @@ class RequestTest extends TestCase
         $_GET = [];
         $_POST = [];
     }
+
+    // ── Attributes ─────────────────────────────────────────────────────────────
+
+    public function test_with_attribute_returns_new_instance(): void
+    {
+        $request = new Request();
+        $with = $request->withAttribute('user', ['id' => 1]);
+
+        $this->assertNotSame($request, $with);
+    }
+
+    public function test_get_attribute_returns_set_value(): void
+    {
+        $user = ['id' => 42, 'email' => 'test@example.com'];
+        $request = (new Request())->withAttribute('user', $user);
+
+        $this->assertSame($user, $request->getAttribute('user'));
+    }
+
+    public function test_get_attribute_returns_default_when_missing(): void
+    {
+        $request = new Request();
+
+        $this->assertNull($request->getAttribute('user'));
+        $this->assertSame('guest', $request->getAttribute('user', 'guest'));
+    }
+
+    public function test_original_request_unaffected_after_with_attribute(): void
+    {
+        $request = new Request();
+        $request->withAttribute('user', ['id' => 1]);
+
+        $this->assertNull($request->getAttribute('user'));
+    }
+
+    public function test_attributes_chain(): void
+    {
+        $request = (new Request())
+            ->withAttribute('user', ['id' => 1])
+            ->withAttribute('role', 'admin');
+
+        $this->assertSame(['id' => 1], $request->getAttribute('user'));
+        $this->assertSame('admin', $request->getAttribute('role'));
+    }
 }

--- a/tests/Tenant/Resolver/SessionTenantResolverTest.php
+++ b/tests/Tenant/Resolver/SessionTenantResolverTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Tenant\Resolver;
+
+use EntityForge\Tenant\Resolver\SessionTenantResolver;
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+class SessionTenantResolverTest extends TestCase
+{
+    public function test_resolves_tenant_from_context_session(): void
+    {
+        $resolver = new SessionTenantResolver();
+
+        $tenantId = $resolver->resolve(['session' => ['tenant_id' => 'acme']]);
+
+        $this->assertSame('acme', $tenantId);
+    }
+
+    public function test_resolves_tenant_from_custom_session_key(): void
+    {
+        $resolver = new SessionTenantResolver('current_tenant');
+
+        $tenantId = $resolver->resolve(['session' => ['current_tenant' => 'bigcorp']]);
+
+        $this->assertSame('bigcorp', $tenantId);
+    }
+
+    public function test_throws_when_session_key_missing(): void
+    {
+        $resolver = new SessionTenantResolver();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches("/Tenant key 'tenant_id' not found in session/");
+
+        $resolver->resolve(['session' => []]);
+    }
+
+    public function test_throws_when_session_value_is_empty_string(): void
+    {
+        $resolver = new SessionTenantResolver();
+
+        $this->expectException(Exception::class);
+
+        $resolver->resolve(['session' => ['tenant_id' => '']]);
+    }
+
+    public function test_casts_non_string_session_value_to_string(): void
+    {
+        $resolver = new SessionTenantResolver();
+
+        $tenantId = $resolver->resolve(['session' => ['tenant_id' => 42]]);
+
+        $this->assertSame('42', $tenantId);
+    }
+}

--- a/tests/Tenant/Resolver/SessionTenantResolverTest.php
+++ b/tests/Tenant/Resolver/SessionTenantResolverTest.php
@@ -53,4 +53,50 @@ class SessionTenantResolverTest extends TestCase
 
         $this->assertSame('42', $tenantId);
     }
+
+    // ── $_SESSION fallback path ─────────────────────────────────────────────────
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_resolves_tenant_from_global_session(): void
+    {
+        session_start();
+        $_SESSION['tenant_id'] = 'from-session';
+
+        $resolver = new SessionTenantResolver();
+        $tenantId = $resolver->resolve([]);
+
+        $this->assertSame('from-session', $tenantId);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_throws_when_global_session_key_missing(): void
+    {
+        $resolver = new SessionTenantResolver();
+        $_SESSION = [];
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches("/Tenant key 'tenant_id' not found in session/");
+
+        $resolver->resolve([]);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_throws_when_global_session_value_is_empty_string(): void
+    {
+        $resolver = new SessionTenantResolver();
+        $_SESSION['tenant_id'] = '';
+
+        $this->expectException(Exception::class);
+
+        $resolver->resolve([]);
+    }
 }

--- a/tests/Tenant/TenantRepositoryTest.php
+++ b/tests/Tenant/TenantRepositoryTest.php
@@ -78,6 +78,27 @@ class TenantRepositoryTest extends TestCase
 
     #[RunInSeparateProcess]
     #[PreserveGlobalState(false)]
+    public function test_all_throws_when_query_returns_false(): void
+    {
+        $pdo = Mockery::mock(PDO::class);
+        $pdo->allows('query')
+            ->with('SELECT * FROM tenants')
+            ->andReturn(false);
+
+        /** @var MockInterface&Connection $conn */
+        $conn = Mockery::mock('overload:' . Connection::class);
+        $conn->allows('getPdo')->andReturn($pdo);
+
+        $repo = new TenantRepository($this->dbConfig());
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches('/Failed to query tenants/');
+
+        $repo->all();
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function test_all_active_returns_only_active_tenants(): void
     {
         $rows = [['id' => 1, 'tenant_id' => 'acme', 'name' => 'Acme', 'status' => 'active']];

--- a/tests/Tenant/TenantResolverFactoryTest.php
+++ b/tests/Tenant/TenantResolverFactoryTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Tenant;
 
 use EntityForge\Tenant\Resolver\HeaderTenantResolver;
+use EntityForge\Tenant\Resolver\SessionTenantResolver;
 use EntityForge\Tenant\Resolver\SubdomainTenantResolver;
 use EntityForge\Tenant\TenantResolverFactory;
 use Exception;
@@ -55,6 +56,23 @@ class TenantResolverFactoryTest extends TestCase
 
         $tenantId = $resolver->resolve(['host' => 'acme.example.com']);
         $this->assertSame('acme', $tenantId);
+    }
+
+    public function test_creates_session_resolver(): void
+    {
+        $resolver = TenantResolverFactory::create(['tenancy' => ['resolver' => 'session']]);
+
+        $this->assertInstanceOf(SessionTenantResolver::class, $resolver);
+    }
+
+    public function test_session_resolver_uses_configured_key(): void
+    {
+        $resolver = TenantResolverFactory::create([
+            'tenancy' => ['resolver' => 'session', 'session_key' => 'current_tenant'],
+        ]);
+
+        $tenantId = $resolver->resolve(['session' => ['current_tenant' => 'corp']]);
+        $this->assertSame('corp', $tenantId);
     }
 
     public function test_throws_for_unsupported_resolver_type(): void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+if (!function_exists('getallheaders')) {
+    function getallheaders(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
## PHPStan Level 8
- Raised from level 5 to level 8
- Fixed 80 errors across 27 files: array generics (`array<string, mixed>`),
  false-return guards (`file_get_contents`, `glob`, `PDO::query`, `parse_url`),
  null-coalescing throws for `TenantContext::getTenantId()`

## EntityBuilder — Typed Relation Properties
- `belongsTo` now generates `public ?User $user = null;` instead of a
  string-returning stub method
- `hasMany` generates `/** @var Order[] */ public array $orders = [];`
- Both inject the correct `use App\Entity\ClassName;` import automatically
- Added `pluralize()` helper handling common irregular forms
  (`category → categories`, `address → addresses`)

## Session Tenant Resolver
- New `SessionTenantResolver` reads from `context['session']` (testable)
  or falls back to `$_SESSION` in production
- Starts the session automatically if not yet active
- Configure with `tenancy.resolver: session` and optional `tenancy.session_key`
  (default: `tenant_id`)

## Scaffolding Commands
- `php bin/ef make:middleware AuthMiddleware` — generates a `MiddlewareInterface`
  stub in `app/Http/Middleware/`
- `php bin/ef make:middleware FirebaseAuth --auth` — generates an
  `AuthMiddlewareInterface` stub with annotated steps for credential
  extraction, provider verification, identity attachment, and early failure return
- `php bin/ef make:controller UserController` — generates a CRUD stub
  (`index`, `show`, `store`, `update`, `destroy`) in `app/Http/Controller/`
- Both commands validate PascalCase names and support `--output` to override
  the destination directory

## Auth Integration Layer
- `AuthMiddlewareInterface` — marker interface extending `MiddlewareInterface`;
  the designated integration point for any auth provider (Firebase, Auth0,
  custom JWT, etc.)
- `Request::withAttribute(key, value)` — attaches per-request data immutably
- `Request::getAttribute(key, default)` — reads it back downstream
- Framework ships zero auth logic; providers plug in via middleware

## Type System Polish
- `EntityBuilder::mapType()` now maps `float → float`, `bool → bool`,
  `text → string`, `datetime → string`; previously all fell through to `mixed`
- `SchemaValidator` extended allowed field types to include `text` and `datetime`

## Documentation
- `readme.md` — updated Request section, added "Integrating Auth" guide with
  full pipeline example, PHPStan added to Running Tests
- `docs/ARCHITECTURE.md` — Code Generation section updated for typed relation
  properties; Request section updated for attributes; Auth integration section added
- `docs/CONCEPT.md` — Entity, Request, Pipeline, and new AuthMiddlewareInterface
  entries updated
- `docs/CLEANUP.md` — Code Generator section updated with relation property
  behaviour and pluralisation note

## Tests
- 300 tests, 0 failures, PHPStan level 8 clean
- +25 new tests covering: `SessionTenantResolver`, `MakeMiddlewareCommand`,
  `MakeControllerCommand`, `Request` attributes, updated `EntityBuilderTest`
  and `SchemaValidatorTest` for new type mappings