### PR TITLE
v2.1.0 — Multi-tenant correctness, code generation fixes, and HTTP improvements

### DIFF
--- a/bin/ef
+++ b/bin/ef
@@ -1,7 +1,14 @@
 #!/usr/bin/env php
 <?php
 
-require __DIR__ . '/../vendor/autoload.php';
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    require __DIR__ . '/../vendor/autoload.php';
+} elseif (file_exists(__DIR__ . '/../../../autoload.php')) {
+    require __DIR__ . '/../../../autoload.php';
+} else {
+    fwrite(STDERR, "Error: cannot find autoload.php — run 'composer install' first\n");
+    exit(1);
+}
 
 use Symfony\Component\Console\Application;
 use EntityForge\Console\GenerateCommand;

--- a/src/Console/GenerateAllCommand.php
+++ b/src/Console/GenerateAllCommand.php
@@ -7,6 +7,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Yaml\Yaml;
 
 class GenerateAllCommand extends Command
 {
@@ -99,11 +100,13 @@ class GenerateAllCommand extends Command
             return Command::FAILURE;
         }
 
-        $pkMap = [];
-        foreach ($configs as $entityName => $config) {
-            $fields = $config['fields'] ?? [];
-            $candidate = strtolower($entityName) . '_id';
-            $pkMap[$entityName] = isset($fields['id']) ? 'id' : (isset($fields[$candidate]) ? $candidate : 'id');
+        $pkMap = array_fill_keys(array_keys($configs), 'id');
+
+        $strategy = 'shared';
+        $appYaml = getcwd() . '/config/application.yaml';
+        if (file_exists($appYaml)) {
+            $yaml = Yaml::parseFile($appYaml);
+            $strategy = $yaml['tenancy']['strategy'] ?? 'shared';
         }
 
         $withMigration = $input->getOption('migration');
@@ -113,7 +116,7 @@ class GenerateAllCommand extends Command
 
         foreach ($configs as $entityName => $config) {
             try {
-                $generator->generate($config, $withMigration, $pkMap);
+                $generator->generate($config, $withMigration, $pkMap, $strategy);
                 $output->writeln("<info>Generated {$entityName}</info>");
             } catch (\Throwable $e) {
                 $output->writeln("<error>{$e->getMessage()}</error>");

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Yaml\Yaml;
 
 class GenerateCommand extends Command
 {
@@ -42,10 +43,17 @@ class GenerateCommand extends Command
             return Command::FAILURE;
         }
 
+        $strategy = 'shared';
+        $appYaml = getcwd() . '/config/application.yaml';
+        if (file_exists($appYaml)) {
+            $yaml = Yaml::parseFile($appYaml);
+            $strategy = $yaml['tenancy']['strategy'] ?? 'shared';
+        }
+
         $generator = new EntityGenerator();
 
         try {
-            $generator->generate($config, $withMigration);
+            $generator->generate($config, $withMigration, [], $strategy);
             $output->writeln("<info>Generated {$entity} successfully.</info>");
         } catch (\Throwable $e) {
             $output->writeln("<error>Error generating {$entity}: {$e->getMessage()}</error>");

--- a/src/Console/MigrateAllTenantsCommand.php
+++ b/src/Console/MigrateAllTenantsCommand.php
@@ -30,7 +30,7 @@ class MigrateAllTenantsCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $app = new Application(__DIR__ . '/../../config');
+        $app = new Application(getcwd() . '/config');
         $app->boot([], false);
         $config = $app->getConfig();
 

--- a/src/Console/MigrateAllTenantsCommand.php
+++ b/src/Console/MigrateAllTenantsCommand.php
@@ -109,7 +109,7 @@ class MigrateAllTenantsCommand extends Command
         $dbConfig['database'] = $dbConfig['database'] . '_' . $tenantId;
 
         try {
-            $runner = new MigrationRunner(new Connection($dbConfig));
+            $runner = new MigrationRunner(new Connection($dbConfig), fn(string $msg) => $output->writeln($msg));
             $runner->run('database/migrations', $dryRun);
             $output->writeln($dryRun
                 ? "<comment>Dry run: {$tenantId}</comment>"

--- a/src/Console/MigrateCommand.php
+++ b/src/Console/MigrateCommand.php
@@ -26,7 +26,7 @@ class MigrateCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $app = new Application(__DIR__ . '/../../config');
+        $app = new Application(getcwd() . '/config');
         $app->boot([], false);
 
         $config = $app->getConfig()['database'];

--- a/src/Console/MigrateCommand.php
+++ b/src/Console/MigrateCommand.php
@@ -33,7 +33,7 @@ class MigrateCommand extends Command
 
         $dryRun = (bool) $input->getOption('dry-run');
         $connection = new Connection($config);
-        $runner = new MigrationRunner($connection);
+        $runner = new MigrationRunner($connection, fn(string $msg) => $output->writeln($msg));
 
         try {
             $runner->run('database/migrations', $dryRun);

--- a/src/Console/RollbackCommand.php
+++ b/src/Console/RollbackCommand.php
@@ -32,7 +32,7 @@ class RollbackCommand extends Command
         $db = $app->getConfig()['database'];
 
         $dryRun = (bool) $input->getOption('dry-run');
-        $runner = new MigrationRunner(new Connection($db));
+        $runner = new MigrationRunner(new Connection($db), fn(string $msg) => $output->writeln($msg));
 
         try {
             $runner->rollback('database/migrations', $dryRun);

--- a/src/Console/RollbackCommand.php
+++ b/src/Console/RollbackCommand.php
@@ -26,7 +26,7 @@ class RollbackCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $app = new Application(__DIR__ . '/../../config');
+        $app = new Application(getcwd() . '/config');
         $app->boot([], false);
 
         $db = $app->getConfig()['database'];

--- a/src/Console/TenantCreateCommand.php
+++ b/src/Console/TenantCreateCommand.php
@@ -30,7 +30,7 @@ class TenantCreateCommand extends Command
         $tenantId = $input->getArgument('tenantId');
         $name = $input->getOption('name') ?? $tenantId;
 
-        $app = new Application(__DIR__ . '/../../config');
+        $app = new Application(getcwd() . '/config');
         $app->boot([], false);
 
         $service = new TenantService($app->getConfig());

--- a/src/Database/MigrationRunner.php
+++ b/src/Database/MigrationRunner.php
@@ -7,10 +7,15 @@ use PDO;
 class MigrationRunner
 {
     private Connection $connection;
+    /** @var callable(string): void */
+    private $output;
 
-    public function __construct(Connection $connection)
+    public function __construct(Connection $connection, ?callable $output = null)
     {
         $this->connection = $connection;
+        $this->output = $output ?? static function (string $msg): void {
+            echo $msg . "\n";
+        };
     }
 
     public function run(string $path, bool $dryRun = false): void
@@ -25,7 +30,7 @@ class MigrationRunner
         sort($files);
 
         if (empty($files)) {
-            echo "No migrations found.\n";
+            ($this->output)('No migrations found.');
             return;
         }
 
@@ -37,12 +42,12 @@ class MigrationRunner
             $name = basename($file);
 
             if (in_array($name, $executed, true)) {
-                echo "{$prefix}Skipped (already executed): {$name}\n";
+                ($this->output)("{$prefix}Skipped (already executed): {$name}");
                 continue;
             }
 
             if ($dryRun) {
-                echo "{$prefix}Would execute: {$name}\n";
+                ($this->output)("{$prefix}Would execute: {$name}");
                 continue;
             }
 
@@ -54,13 +59,13 @@ class MigrationRunner
             try {
                 $pdo->exec($sql);
                 $this->mark($name, $batch);
-                echo "Executed: {$name}\n";
+                ($this->output)("Executed: {$name}");
             } catch (\Throwable $e) {
                 throw new \Exception("Migration failed: {$name} - " . $e->getMessage());
             }
         }
 
-        echo $dryRun ? "{$prefix}Done (no changes applied)\n" : "✔ Done\n";
+        ($this->output)($dryRun ? "{$prefix}Done (no changes applied)" : '✔ Done');
     }
 
     public function rollback(string $path, bool $dryRun = false): void
@@ -70,7 +75,7 @@ class MigrationRunner
         $batch  = $this->lastBatch();
 
         if ($batch === 0) {
-            echo "Nothing to rollback.\n";
+            ($this->output)('Nothing to rollback.');
             return;
         }
 
@@ -89,7 +94,7 @@ class MigrationRunner
             }
 
             if ($dryRun) {
-                echo "{$prefix}Would roll back: {$migration}\n";
+                ($this->output)("{$prefix}Would roll back: {$migration}");
                 continue;
             }
 
@@ -100,18 +105,15 @@ class MigrationRunner
 
             try {
                 $pdo->exec($sql);
-
                 $pdo->prepare("DELETE FROM migrations WHERE migration = :m")
                     ->execute(['m' => $migration]);
-
-                echo "Rolled back: {$migration}\n";
-
+                ($this->output)("Rolled back: {$migration}");
             } catch (\Throwable $e) {
                 throw new \Exception("Rollback failed: {$migration} - " . $e->getMessage());
             }
         }
 
-        echo $dryRun ? "{$prefix}Done (no changes applied)\n" : "✔ Rollback complete\n";
+        ($this->output)($dryRun ? "{$prefix}Done (no changes applied)" : '✔ Rollback complete');
     }
 
     private function ensureMigrationsTable(): void
@@ -137,9 +139,7 @@ class MigrationRunner
         }
     }
 
-    /**
-     * @return array<int, string>
-     */
+    /** @return array<int, string> */
     private function getExecuted(): array
     {
         $stmt = $this->connection->getPdo()->query("SELECT migration FROM migrations");
@@ -149,9 +149,7 @@ class MigrationRunner
         return $stmt->fetchAll(PDO::FETCH_COLUMN);
     }
 
-    /**
-     * @return array<int, string>
-     */
+    /** @return array<int, string> */
     private function getExecutedSafe(): array
     {
         try {
@@ -163,14 +161,9 @@ class MigrationRunner
 
     private function mark(string $migration, int $batch): void
     {
-        $stmt = $this->connection->getPdo()->prepare(
-            "INSERT INTO migrations (migration, batch) VALUES (:m, :b)"
-        );
-
-        $stmt->execute([
-            'm' => $migration,
-            'b' => $batch
-        ]);
+        $this->connection->getPdo()
+            ->prepare("INSERT INTO migrations (migration, batch) VALUES (:m, :b)")
+            ->execute(['m' => $migration, 'b' => $batch]);
     }
 
     private function nextBatch(): int

--- a/src/Generator/Builder/EntityBuilder.php
+++ b/src/Generator/Builder/EntityBuilder.php
@@ -1,14 +1,16 @@
 <?php
+
 namespace EntityForge\Generator\Builder;
 
 use EntityForge\Generator\Schema\EntitySchema;
+use EntityForge\Support\Str;
 
 class EntityBuilder
 {
     public function build(EntitySchema $schema): string
     {
         $className = $schema->getEntityName();
-        $fields = $schema->getFields();
+        $fields    = $schema->getFields();
 
         $properties = '';
         foreach ($fields as $name => $type) {
@@ -16,9 +18,8 @@ class EntityBuilder
         }
 
         $relationsCode = $this->buildRelations($schema);
-        $useBlock = $this->buildUseStatements($schema);
-
-        $body = $properties . ($relationsCode !== '' ? "\n{$relationsCode}" : '');
+        $useBlock      = $this->buildUseStatements($schema);
+        $body          = $properties . ($relationsCode !== '' ? "\n{$relationsCode}" : '');
 
         return <<<PHP
 <?php
@@ -35,18 +36,18 @@ PHP;
     private function mapType(string $type): string
     {
         return match ($type) {
-            'int'                    => 'int',
-            'float'                  => 'float',
-            'bool'                   => 'bool',
+            'int'                        => 'int',
+            'float'                      => 'float',
+            'bool'                       => 'bool',
             'string', 'text', 'datetime' => 'string',
-            default                  => 'mixed',
+            default                      => 'mixed',
         };
     }
 
     private function buildUseStatements(EntitySchema $schema): string
     {
         $relations = $schema->getRelations();
-        $entities = [];
+        $entities  = [];
 
         /** @var array<string, string> $belongsTo */
         $belongsTo = $relations['belongsTo'] ?? [];
@@ -75,7 +76,7 @@ PHP;
     private function buildRelations(EntitySchema $schema): string
     {
         $relations = $schema->getRelations();
-        $code = '';
+        $code      = '';
 
         /** @var array<string, string> $belongsTo */
         $belongsTo = $relations['belongsTo'] ?? [];
@@ -88,22 +89,11 @@ PHP;
         /** @var array<string, string> $hasMany */
         $hasMany = $relations['hasMany'] ?? [];
         foreach ($hasMany as $entity => $foreignKey) {
-            $property = $this->pluralize(lcfirst((string) $entity));
+            $property = Str::pluralize(lcfirst((string) $entity));
             $code .= "    /** @var {$entity}[] Loaded via {$foreignKey} */\n";
             $code .= "    public array \${$property} = [];\n";
         }
 
         return $code;
-    }
-
-    private function pluralize(string $word): string
-    {
-        if (str_ends_with($word, 'y') && !preg_match('/[aeiou]y$/i', $word)) {
-            return substr($word, 0, -1) . 'ies';
-        }
-        if (preg_match('/(s|x|z|ch|sh)$/', $word)) {
-            return $word . 'es';
-        }
-        return $word . 's';
     }
 }

--- a/src/Generator/Builder/MigrationBuilder.php
+++ b/src/Generator/Builder/MigrationBuilder.php
@@ -3,25 +3,28 @@
 namespace EntityForge\Generator\Builder;
 
 use EntityForge\Generator\Schema\EntitySchema;
+use EntityForge\Support\Str;
 
 class MigrationBuilder
 {
     /**
-     * @param array<string, string> $pkMap  entity name → primary key column, used to resolve FK targets
+     * @param array<string, string> $pkMap     entity name → primary key column, used to resolve FK targets
+     * @param string                $strategy  tenancy strategy: 'shared' adds tenant_id, 'database' omits it
      */
-    public function buildUp(EntitySchema $schema, array $pkMap = []): string
+    public function buildUp(EntitySchema $schema, array $pkMap = [], string $strategy = 'shared'): string
     {
-        $table     = strtolower($schema->getEntityName()) . 's';
+        $table     = Str::toTableName($schema->getEntityName());
         $fields    = $schema->getFields();
         $relations = $schema->getRelations();
         $indexes   = $schema->getIndexes();
 
         $fkColumns = array_values($relations['belongsTo'] ?? []);
 
-        $definitions = [
-            'id INT AUTO_INCREMENT PRIMARY KEY',
-            'tenant_id VARCHAR(255) NOT NULL',
-        ];
+        $definitions = ['id INT AUTO_INCREMENT PRIMARY KEY'];
+
+        if ($strategy === 'shared') {
+            $definitions[] = 'tenant_id VARCHAR(255) NOT NULL';
+        }
 
         foreach ($fields as $name => $type) {
             if ($name === 'id' || $name === 'tenant_id' || in_array($name, $fkColumns, true)) {
@@ -31,7 +34,7 @@ class MigrationBuilder
         }
 
         foreach ($relations['belongsTo'] ?? [] as $refEntity => $fkColumn) {
-            $refTable   = strtolower($refEntity) . 's';
+            $refTable   = Str::toTableName($refEntity);
             $refPk      = $pkMap[$refEntity] ?? 'id';
             $constraint = "fk_{$table}_{$fkColumn}";
             $definitions[] = "{$fkColumn} INT NOT NULL";
@@ -58,7 +61,7 @@ SQL;
 
     public function buildDown(EntitySchema $schema): string
     {
-        $table = strtolower($schema->getEntityName()) . 's';
+        $table = Str::toTableName($schema->getEntityName());
         return "DROP TABLE IF EXISTS {$table};";
     }
 

--- a/src/Generator/Builder/MigrationBuilder.php
+++ b/src/Generator/Builder/MigrationBuilder.php
@@ -15,18 +15,26 @@ class MigrationBuilder
         $fields    = $schema->getFields();
         $relations = $schema->getRelations();
         $indexes   = $schema->getIndexes();
-        $pk        = $schema->getPrimaryKey();
 
-        $definitions = [];
+        $fkColumns = array_values($relations['belongsTo'] ?? []);
+
+        $definitions = [
+            'id INT AUTO_INCREMENT PRIMARY KEY',
+            'tenant_id VARCHAR(255) NOT NULL',
+        ];
 
         foreach ($fields as $name => $type) {
-            $definitions[] = $this->mapColumn($name, $type, $pk ?? '');
+            if ($name === 'id' || $name === 'tenant_id' || in_array($name, $fkColumns, true)) {
+                continue;
+            }
+            $definitions[] = $this->mapColumn($name, $type);
         }
 
         foreach ($relations['belongsTo'] ?? [] as $refEntity => $fkColumn) {
             $refTable   = strtolower($refEntity) . 's';
             $refPk      = $pkMap[$refEntity] ?? 'id';
             $constraint = "fk_{$table}_{$fkColumn}";
+            $definitions[] = "{$fkColumn} INT NOT NULL";
             $definitions[] = "CONSTRAINT {$constraint} FOREIGN KEY ({$fkColumn}) REFERENCES {$refTable}({$refPk})";
         }
 
@@ -54,19 +62,16 @@ SQL;
         return "DROP TABLE IF EXISTS {$table};";
     }
 
-    private function mapColumn(string $name, string $type, string $pk = 'id'): string
+    private function mapColumn(string $name, string $type): string
     {
         $sqlType = match ($type) {
-            'int' => 'INT',
-            'string' => 'VARCHAR(255)',
-            'float' => 'FLOAT',
-            'bool' => 'BOOLEAN',
-            default => 'TEXT'
+            'int'      => 'INT',
+            'string'   => 'VARCHAR(255)',
+            'float'    => 'FLOAT',
+            'bool'     => 'BOOLEAN',
+            'datetime' => 'DATETIME',
+            default    => 'TEXT'
         };
-
-        if ($name === $pk) {
-            return "{$pk} INT PRIMARY KEY AUTO_INCREMENT";
-        }
 
         return "{$name} {$sqlType}";
     }

--- a/src/Generator/Builder/MigrationBuilder.php
+++ b/src/Generator/Builder/MigrationBuilder.php
@@ -42,11 +42,17 @@ class MigrationBuilder
         }
 
         foreach ($indexes as $index) {
-            $cols    = implode(', ', $index['columns']);
-            $slug    = implode('_', $index['columns']);
             $unique  = $index['unique'] ?? false;
-            $type    = $unique ? 'UNIQUE INDEX' : 'INDEX';
-            $prefix  = $unique ? 'uix' : 'idx';
+            $columns = $index['columns'];
+
+            if ($unique && $strategy === 'shared') {
+                $columns = array_unique(array_merge(['tenant_id'], $columns));
+            }
+
+            $cols   = implode(', ', $columns);
+            $slug   = implode('_', $columns);
+            $type   = $unique ? 'UNIQUE INDEX' : 'INDEX';
+            $prefix = $unique ? 'uix' : 'idx';
             $definitions[] = "{$type} {$prefix}_{$table}_{$slug} ({$cols})";
         }
 

--- a/src/Generator/EntityGenerator.php
+++ b/src/Generator/EntityGenerator.php
@@ -8,6 +8,7 @@ use EntityForge\Generator\Builder\EntityBuilder;
 use EntityForge\Generator\Builder\RepositoryBuilder;
 use EntityForge\Generator\Builder\MigrationBuilder;
 use EntityForge\Generator\Writer\FileWriter;
+use EntityForge\Support\Str;
 
 class EntityGenerator
 {
@@ -17,70 +18,59 @@ class EntityGenerator
     private MigrationBuilder $migrationBuilder;
     private FileWriter $writer;
 
-    // Shared counter for this generation session
     private int $migrationCounter = 0;
 
     public function __construct()
     {
-        $this->validator = new SchemaValidator();
-        $this->entityBuilder = new EntityBuilder();
+        $this->validator         = new SchemaValidator();
+        $this->entityBuilder     = new EntityBuilder();
         $this->repositoryBuilder = new RepositoryBuilder();
-        $this->migrationBuilder = new MigrationBuilder();
-        $this->writer = new FileWriter();
+        $this->migrationBuilder  = new MigrationBuilder();
+        $this->writer            = new FileWriter();
     }
 
     /**
      * @param array<string, mixed> $config
-     * @param array<string, string> $pkMap  entity name → primary key column for FK resolution
+     * @param array<string, string> $pkMap      entity name → primary key column for FK resolution
+     * @param string                $strategy   tenancy strategy — passed through to MigrationBuilder
      */
-    public function generate(array $config, bool $withMigration = false, array $pkMap = []): void
-    {
-        // Validate config
+    public function generate(
+        array $config,
+        bool $withMigration = false,
+        array $pkMap = [],
+        string $strategy = 'shared'
+    ): void {
         $this->validator->validate($config);
 
-        $schema = new EntitySchema($config);
+        $schema     = new EntitySchema($config);
         $entityName = $schema->getEntityName();
 
-        // Generate code
-        $entityCode = $this->entityBuilder->build($schema);
-        $repositoryCode = $this->repositoryBuilder->build($schema);
+        $this->writer->write("app/Entity/{$entityName}.php", $this->entityBuilder->build($schema));
+        $this->writer->write("app/Repository/{$entityName}Repository.php", $this->repositoryBuilder->build($schema));
 
-        // Write entity + repository
-        $this->writer->write("app/Entity/{$entityName}.php", $entityCode);
-        $this->writer->write("app/Repository/{$entityName}Repository.php", $repositoryCode);
-
-        // Generate migration
         if ($withMigration) {
             $baseName = $this->generateMigrationBaseName($entityName);
 
-            $upSql = $this->migrationBuilder->buildUp($schema, $pkMap);
-            $downSql = $this->migrationBuilder->buildDown($schema);
-
             $this->writer->write(
                 "database/migrations/{$baseName}.up.sql",
-                $upSql
+                $this->migrationBuilder->buildUp($schema, $pkMap, $strategy)
             );
-
             $this->writer->write(
-            "database/migrations/{$baseName}.down.sql",
-                $downSql
+                "database/migrations/{$baseName}.down.sql",
+                $this->migrationBuilder->buildDown($schema)
             );
         }
     }
 
     private function generateMigrationBaseName(string $entity): string
     {
-        $timestamp = date('Y_m_d_His');
-
         $this->migrationCounter++;
-
-        $table = strtolower($entity) . 's';
 
         return sprintf(
             '%s_%04d_create_%s_table',
-            $timestamp,
+            date('Y_m_d_His'),
             $this->migrationCounter,
-            $table
+            Str::toTableName($entity)
         );
     }
 }

--- a/src/Generator/Schema/EntitySchema.php
+++ b/src/Generator/Schema/EntitySchema.php
@@ -18,27 +18,14 @@ class EntitySchema
         return $this->config['entity'];
     }
 
-    public function isMultiTenant(): bool
-    {
-        return $this->config['multiTenant'] ?? false;
-    }
-
     public function hasTimestamps(): bool
     {
         return $this->config['timestamps'] ?? false;
     }
 
-    public function getPrimaryKey(): ?string
+    public function getPrimaryKey(): string
     {
-        $fields = $this->config['fields'] ?? [];
-        if (isset($fields['id'])) {
-            return 'id';
-        }
-        $candidate = strtolower($this->config['entity']) . '_id';
-        if (isset($fields[$candidate])) {
-            return $candidate;
-        }
-        return null;
+        return 'id';
     }
 
     /** @return array<string, string> */
@@ -46,14 +33,9 @@ class EntitySchema
     {
         $fields = $this->config['fields'] ?? [];
 
-        if ($this->isMultiTenant()) {
-            $fields['tenant_id'] = 'string';
-        }
-
-        // Timestamp Support
         if ($this->hasTimestamps()) {
-            $fields['created_at'] = 'string';
-            $fields['updated_at'] = 'string';
+            $fields['created_at'] = 'datetime';
+            $fields['updated_at'] = 'datetime';
         }
 
         return $fields;

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -23,14 +23,21 @@ class Request
 
     public static function capture(): self
     {
-        $uri    = $_SERVER['REQUEST_URI'] ?? '/';
-        $parsed = parse_url($uri, PHP_URL_PATH);
-        $path   = is_string($parsed) ? $parsed : '/';
+        $uri         = $_SERVER['REQUEST_URI'] ?? '/';
+        $parsed      = parse_url($uri, PHP_URL_PATH);
+        $path        = is_string($parsed) ? $parsed : '/';
+        $contentType = $_SERVER['CONTENT_TYPE'] ?? '';
+
+        $body = $_POST;
+        if (str_contains($contentType, 'application/json')) {
+            $raw  = file_get_contents('php://input');
+            $body = $raw ? (json_decode($raw, true) ?? []) : [];
+        }
 
         return new self(
             headers: getallheaders() ?: [],
             query: $_GET,
-            body: $_POST,
+            body: $body,
             method: $_SERVER['REQUEST_METHOD'] ?? 'GET',
             path: $path
         );
@@ -49,6 +56,12 @@ class Request
     public function body(string $key): mixed
     {
         return $this->body[$key] ?? null;
+    }
+
+    /** @return array<string, mixed> */
+    public function json(): array
+    {
+        return $this->body;
     }
 
     public function method(): string

--- a/src/Repository/BaseRepository.php
+++ b/src/Repository/BaseRepository.php
@@ -3,6 +3,7 @@
 namespace EntityForge\Repository;
 
 use EntityForge\Database\Connection;
+use EntityForge\Support\Str;
 use EntityForge\Tenant\TenantConnectionResolver;
 use EntityForge\Tenant\TenantContext;
 use EntityForge\Tenant\TenantGuard;
@@ -33,11 +34,8 @@ abstract class BaseRepository
 
     protected function resolveTableName(): string
     {
-        $class = (new \ReflectionClass($this))
-            ->getShortName();
-        return strtolower(
-                str_replace('Repository', '', $class)
-            ) . 's';
+        $class = (new \ReflectionClass($this))->getShortName();
+        return Str::toTableName(str_replace('Repository', '', $class));
     }
 
     /**
@@ -63,13 +61,9 @@ abstract class BaseRepository
         return $data;
     }
 
-    /**
-     * Determine if tenant scope should be applied
-     */
     protected function shouldApplyTenantScope(): bool
     {
-        return ($this->config['tenancy']['strategy'] ?? 'shared')
-            === 'shared';
+        return ($this->config['tenancy']['strategy'] ?? 'shared') === 'shared';
     }
 
     /**
@@ -85,10 +79,7 @@ abstract class BaseRepository
 
         array_walk($columns, fn(string $c) => $this->assertColumnName($c));
 
-        $placeholders = array_map(
-            fn(string $column) => ':' . $column,
-            $columns
-        );
+        $placeholders = array_map(fn(string $column) => ':' . $column, $columns);
 
         $sql = sprintf(
             'INSERT INTO %s (%s) VALUES (%s)',
@@ -97,13 +88,10 @@ abstract class BaseRepository
             implode(', ', $placeholders)
         );
 
-        $statement = $this->connection
-            ->getPdo()
-            ->prepare($sql);
+        $pdo = $this->connection->getPdo();
+        $pdo->prepare($sql)->execute($data);
 
-        $statement->execute($data);
-
-        return $data;
+        return ['id' => (int) $pdo->lastInsertId()] + $data;
     }
 
     /**
@@ -113,19 +101,14 @@ abstract class BaseRepository
     public function findAll(): array
     {
         $sql = "SELECT * FROM {$this->table}";
-
         $params = [];
 
         if ($this->shouldApplyTenantScope()) {
             $sql .= " WHERE tenant_id = :tenant_id";
-
             $params['tenant_id'] = $this->getTenantId();
         }
 
-        $statement = $this->connection
-            ->getPdo()
-            ->prepare($sql);
-
+        $statement = $this->connection->getPdo()->prepare($sql);
         $statement->execute($params);
 
         return $statement->fetchAll(PDO::FETCH_ASSOC);
@@ -138,25 +121,17 @@ abstract class BaseRepository
     public function findById(int $id): ?array
     {
         $sql = "SELECT * FROM {$this->table} WHERE id = :id";
-
-        $params = [
-            'id' => $id,
-        ];
+        $params = ['id' => $id];
 
         if ($this->shouldApplyTenantScope()) {
             $sql .= " AND tenant_id = :tenant_id";
-
             $params['tenant_id'] = $this->getTenantId();
         }
 
-        $statement = $this->connection
-            ->getPdo()
-            ->prepare($sql);
-
+        $statement = $this->connection->getPdo()->prepare($sql);
         $statement->execute($params);
 
         $result = $statement->fetch(PDO::FETCH_ASSOC);
-
         return $result ?: null;
     }
 
@@ -168,7 +143,6 @@ abstract class BaseRepository
     public function where(array $conditions): array
     {
         $clauses = [];
-
         $params = [];
 
         foreach ($conditions as $column => $value) {
@@ -179,7 +153,6 @@ abstract class BaseRepository
 
         if ($this->shouldApplyTenantScope()) {
             $clauses[] = "tenant_id = :tenant_id";
-
             $params['tenant_id'] = $this->getTenantId();
         }
 
@@ -189,10 +162,7 @@ abstract class BaseRepository
             implode(' AND ', $clauses)
         );
 
-        $statement = $this->connection
-            ->getPdo()
-            ->prepare($sql);
-
+        $statement = $this->connection->getPdo()->prepare($sql);
         $statement->execute($params);
 
         return $statement->fetchAll(PDO::FETCH_ASSOC);
@@ -218,66 +188,44 @@ abstract class BaseRepository
         );
 
         $params = $data;
-
         $params['id'] = $id;
 
         if ($this->shouldApplyTenantScope()) {
             $sql .= " AND tenant_id = :tenant_id";
-
             $params['tenant_id'] = $this->getTenantId();
         }
 
-        $statement = $this->connection
-            ->getPdo()
-            ->prepare($sql);
-
-        return $statement->execute($params);
+        return $this->connection->getPdo()->prepare($sql)->execute($params);
     }
 
     /**
-     * Delete record by ID
-     *
      * @throws Exception
      */
     public function delete(int $id): bool
     {
         $sql = "DELETE FROM {$this->table} WHERE id = :id";
-
-        $params = [
-            'id' => $id,
-        ];
+        $params = ['id' => $id];
 
         if ($this->shouldApplyTenantScope()) {
             $sql .= " AND tenant_id = :tenant_id";
-
             $params['tenant_id'] = $this->getTenantId();
         }
 
-        $statement = $this->connection
-            ->getPdo()
-            ->prepare($sql);
-
-        return $statement->execute($params);
+        return $this->connection->getPdo()->prepare($sql)->execute($params);
     }
 
     public function beginTransaction(): void
     {
-        $this->connection
-            ->getPdo()
-            ->beginTransaction();
+        $this->connection->getPdo()->beginTransaction();
     }
 
     public function commit(): void
     {
-        $this->connection
-            ->getPdo()
-            ->commit();
+        $this->connection->getPdo()->commit();
     }
 
     public function rollback(): void
     {
-        $this->connection
-            ->getPdo()
-            ->rollBack();
+        $this->connection->getPdo()->rollBack();
     }
 }

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -6,7 +6,7 @@ class Str
 {
     public static function toTableName(string $entityName): string
     {
-        $snake = strtolower(preg_replace('/([A-Z])/', '_$1', lcfirst($entityName)));
+        $snake = strtolower((string) preg_replace('/([A-Z])/', '_$1', lcfirst($entityName)));
         return self::pluralize($snake);
     }
 

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace EntityForge\Support;
+
+class Str
+{
+    public static function toTableName(string $entityName): string
+    {
+        $snake = strtolower(preg_replace('/([A-Z])/', '_$1', lcfirst($entityName)));
+        return self::pluralize($snake);
+    }
+
+    public static function pluralize(string $word): string
+    {
+        if (str_ends_with($word, 'y') && !preg_match('/[aeiou]y$/i', $word)) {
+            return substr($word, 0, -1) . 'ies';
+        }
+        if (preg_match('/(s|x|z|ch|sh)$/', $word)) {
+            return $word . 'es';
+        }
+        return $word . 's';
+    }
+}

--- a/src/Tenant/TenantService.php
+++ b/src/Tenant/TenantService.php
@@ -30,7 +30,12 @@ class TenantService
             throw new \Exception("Tenant already exists: {$tenantId}");
         }
 
-        $this->provisioner->create($tenantId);
+        $strategy = $this->config['tenancy']['strategy'] ?? 'shared';
+
+        if ($strategy === 'database') {
+            $this->provisioner->create($tenantId);
+        }
+
         $this->repo->create($tenantId, $name);
     }
 

--- a/tests/Console/ConsoleCommandsTest.php
+++ b/tests/Console/ConsoleCommandsTest.php
@@ -88,6 +88,30 @@ class ConsoleCommandsTest extends TestCase
         $this->assertStringContainsString('Generated Widget', $tester->getDisplay());
     }
 
+    public function test_generate_reads_strategy_from_application_yaml(): void
+    {
+        $tmp = sys_get_temp_dir() . '/ef_con_' . uniqid();
+        mkdir($tmp . '/entities', 0755, true);
+        mkdir($tmp . '/config', 0755, true);
+        file_put_contents($tmp . '/entities/Widget.json', json_encode([
+            'entity' => 'Widget',
+            'fields' => ['name' => 'string'],
+        ]));
+        file_put_contents($tmp . '/config/application.yaml', "tenancy:\n  strategy: database\n");
+
+        $origDir = getcwd();
+        chdir($tmp);
+
+        $tester = new CommandTester(new GenerateCommand());
+        $code = $tester->execute(['entity' => 'Widget', '--config' => 'entities']);
+
+        chdir($origDir);
+        $this->removeDir($tmp);
+
+        $this->assertSame(0, $code);
+        $this->assertStringContainsString('Generated Widget', $tester->getDisplay());
+    }
+
     // ── GenerateAllCommand::execute() ──────────────────────────────────────────
 
     public function test_generate_all_fails_when_config_dir_missing(): void
@@ -182,6 +206,29 @@ class ConsoleCommandsTest extends TestCase
             'entity' => 'Item',
             'fields' => ['id' => 'int'],
         ]));
+        $origDir = getcwd();
+        chdir($tmp);
+
+        $tester = new CommandTester(new GenerateAllCommand());
+        $code = $tester->execute([]);
+
+        chdir($origDir);
+        $this->removeDir($tmp);
+
+        $this->assertSame(0, $code);
+        $this->assertStringContainsString('Generated Item', $tester->getDisplay());
+    }
+
+    public function test_generate_all_reads_strategy_from_application_yaml(): void
+    {
+        $tmp = sys_get_temp_dir() . '/ef_con_' . uniqid();
+        mkdir($tmp . '/config/entities', 0755, true);
+        file_put_contents($tmp . '/config/entities/Item.json', json_encode([
+            'entity' => 'Item',
+            'fields' => ['name' => 'string'],
+        ]));
+        file_put_contents($tmp . '/config/application.yaml', "tenancy:\n  strategy: database\n");
+
         $origDir = getcwd();
         chdir($tmp);
 

--- a/tests/Generator/Builder/MigrationBuilderTest.php
+++ b/tests/Generator/Builder/MigrationBuilderTest.php
@@ -15,9 +15,9 @@ class MigrationBuilderTest extends TestCase
         $this->builder = new MigrationBuilder();
     }
 
-    private function schema(array $fields, string $entity = 'Product'): EntitySchema
+    private function schema(array $fields, string $entity = 'Product', array $extra = []): EntitySchema
     {
-        return new EntitySchema(['entity' => $entity, 'fields' => $fields]);
+        return new EntitySchema(array_merge(['entity' => $entity, 'fields' => $fields], $extra));
     }
 
     public function test_build_up_creates_correct_table_name(): void
@@ -25,6 +25,27 @@ class MigrationBuilderTest extends TestCase
         $sql = $this->builder->buildUp($this->schema([], 'Product'));
 
         $this->assertStringContainsString('CREATE TABLE products', $sql);
+    }
+
+    public function test_build_up_always_includes_id_primary_key(): void
+    {
+        $sql = $this->builder->buildUp($this->schema([]));
+
+        $this->assertStringContainsString('id INT AUTO_INCREMENT PRIMARY KEY', $sql);
+    }
+
+    public function test_build_up_always_includes_tenant_id(): void
+    {
+        $sql = $this->builder->buildUp($this->schema([]));
+
+        $this->assertStringContainsString('tenant_id VARCHAR(255) NOT NULL', $sql);
+    }
+
+    public function test_build_up_does_not_duplicate_id_when_in_schema_fields(): void
+    {
+        $sql = $this->builder->buildUp($this->schema(['id' => 'int']));
+
+        $this->assertEquals(1, substr_count($sql, 'id INT'));
     }
 
     public function test_build_up_maps_int_to_int_column(): void
@@ -55,20 +76,11 @@ class MigrationBuilderTest extends TestCase
         $this->assertStringContainsString('active BOOLEAN', $sql);
     }
 
-    public function test_build_up_maps_id_to_primary_key(): void
+    public function test_build_up_maps_datetime_to_datetime(): void
     {
-        $sql = $this->builder->buildUp($this->schema(['id' => 'int']));
+        $sql = $this->builder->buildUp($this->schema(['date' => 'datetime']));
 
-        $this->assertStringContainsString('id INT PRIMARY KEY AUTO_INCREMENT', $sql);
-    }
-
-    public function test_build_up_unknown_type_maps_to_text(): void
-    {
-        // unknown type falls through match to TEXT via default
-        // float is actually mapped, but testing the column presence
-        $sql = $this->builder->buildUp($this->schema(['note' => 'string']));
-
-        $this->assertStringContainsString('note', $sql);
+        $this->assertStringContainsString('date DATETIME', $sql);
     }
 
     public function test_build_down_drops_correct_table(): void
@@ -85,25 +97,39 @@ class MigrationBuilderTest extends TestCase
         $this->assertStringContainsString('invoices', $sql);
     }
 
-    public function test_build_up_emits_foreign_key_for_belongs_to(): void
+    public function test_build_up_emits_fk_column_and_constraint(): void
     {
         $schema = new EntitySchema([
             'entity'    => 'Order',
-            'fields'    => ['id' => 'int', 'user_id' => 'int'],
+            'fields'    => [],
             'relations' => ['belongsTo' => ['User' => 'user_id']],
         ]);
 
         $sql = $this->builder->buildUp($schema);
 
+        $this->assertStringContainsString('user_id INT NOT NULL', $sql);
         $this->assertStringContainsString('CONSTRAINT fk_orders_user_id', $sql);
         $this->assertStringContainsString('FOREIGN KEY (user_id) REFERENCES users(id)', $sql);
+    }
+
+    public function test_build_up_does_not_duplicate_fk_column_when_in_schema_fields(): void
+    {
+        $schema = new EntitySchema([
+            'entity'    => 'Order',
+            'fields'    => ['user_id' => 'int'],
+            'relations' => ['belongsTo' => ['User' => 'user_id']],
+        ]);
+
+        $sql = $this->builder->buildUp($schema);
+
+        $this->assertEquals(1, substr_count($sql, 'user_id INT'));
     }
 
     public function test_build_up_emits_index(): void
     {
         $schema = new EntitySchema([
             'entity'  => 'Order',
-            'fields'  => ['id' => 'int', 'status' => 'string'],
+            'fields'  => ['status' => 'string'],
             'indexes' => [['columns' => ['status']]],
         ]);
 
@@ -116,7 +142,7 @@ class MigrationBuilderTest extends TestCase
     {
         $schema = new EntitySchema([
             'entity'  => 'User',
-            'fields'  => ['id' => 'int', 'email' => 'string'],
+            'fields'  => ['email' => 'string'],
             'indexes' => [['columns' => ['email'], 'unique' => true]],
         ]);
 
@@ -129,7 +155,7 @@ class MigrationBuilderTest extends TestCase
     {
         $schema = new EntitySchema([
             'entity'  => 'Order',
-            'fields'  => ['id' => 'int', 'user_id' => 'int', 'status' => 'string'],
+            'fields'  => ['status' => 'string'],
             'indexes' => [['columns' => ['user_id', 'status']]],
         ]);
 
@@ -142,13 +168,15 @@ class MigrationBuilderTest extends TestCase
     {
         $schema = new EntitySchema([
             'entity'    => 'OrderItem',
-            'fields'    => ['id' => 'int', 'order_id' => 'int', 'product_id' => 'int'],
+            'fields'    => [],
             'relations' => ['belongsTo' => ['Order' => 'order_id', 'Product' => 'product_id']],
             'indexes'   => [['columns' => ['order_id', 'product_id'], 'unique' => true]],
         ]);
 
         $sql = $this->builder->buildUp($schema);
 
+        $this->assertStringContainsString('order_id INT NOT NULL', $sql);
+        $this->assertStringContainsString('product_id INT NOT NULL', $sql);
         $this->assertStringContainsString('FOREIGN KEY (order_id) REFERENCES orders(id)', $sql);
         $this->assertStringContainsString('FOREIGN KEY (product_id) REFERENCES products(id)', $sql);
         $this->assertStringContainsString('UNIQUE INDEX uix_orderitems_order_id_product_id', $sql);

--- a/tests/Generator/Builder/MigrationBuilderTest.php
+++ b/tests/Generator/Builder/MigrationBuilderTest.php
@@ -41,6 +41,13 @@ class MigrationBuilderTest extends TestCase
         $this->assertStringContainsString('tenant_id VARCHAR(255) NOT NULL', $sql);
     }
 
+    public function test_build_up_database_strategy_omits_tenant_id(): void
+    {
+        $sql = $this->builder->buildUp($this->schema([]), [], 'database');
+
+        $this->assertStringNotContainsString('tenant_id', $sql);
+    }
+
     public function test_build_up_does_not_duplicate_id_when_in_schema_fields(): void
     {
         $sql = $this->builder->buildUp($this->schema(['id' => 'int']));
@@ -179,6 +186,6 @@ class MigrationBuilderTest extends TestCase
         $this->assertStringContainsString('product_id INT NOT NULL', $sql);
         $this->assertStringContainsString('FOREIGN KEY (order_id) REFERENCES orders(id)', $sql);
         $this->assertStringContainsString('FOREIGN KEY (product_id) REFERENCES products(id)', $sql);
-        $this->assertStringContainsString('UNIQUE INDEX uix_orderitems_order_id_product_id', $sql);
+        $this->assertStringContainsString('UNIQUE INDEX uix_order_items_order_id_product_id', $sql);
     }
 }

--- a/tests/Generator/Builder/MigrationBuilderTest.php
+++ b/tests/Generator/Builder/MigrationBuilderTest.php
@@ -185,6 +185,13 @@ class MigrationBuilderTest extends TestCase
         $this->assertStringContainsString('INDEX idx_orders_user_id_status (user_id, status)', $sql);
     }
 
+    public function test_build_up_maps_unknown_type_to_text(): void
+    {
+        $sql = $this->builder->buildUp($this->schema(['data' => 'json']));
+
+        $this->assertStringContainsString('data TEXT', $sql);
+    }
+
     public function test_build_up_emits_multiple_fks_and_indexes(): void
     {
         $schema = new EntitySchema([

--- a/tests/Generator/Builder/MigrationBuilderTest.php
+++ b/tests/Generator/Builder/MigrationBuilderTest.php
@@ -145,7 +145,7 @@ class MigrationBuilderTest extends TestCase
         $this->assertStringContainsString('INDEX idx_orders_status (status)', $sql);
     }
 
-    public function test_build_up_emits_unique_index(): void
+    public function test_build_up_emits_unique_index_shared_prepends_tenant_id(): void
     {
         $schema = new EntitySchema([
             'entity'  => 'User',
@@ -153,9 +153,23 @@ class MigrationBuilderTest extends TestCase
             'indexes' => [['columns' => ['email'], 'unique' => true]],
         ]);
 
-        $sql = $this->builder->buildUp($schema);
+        $sql = $this->builder->buildUp($schema, [], 'shared');
+
+        $this->assertStringContainsString('UNIQUE INDEX uix_users_tenant_id_email (tenant_id, email)', $sql);
+    }
+
+    public function test_build_up_emits_unique_index_database_strategy_no_tenant_id(): void
+    {
+        $schema = new EntitySchema([
+            'entity'  => 'User',
+            'fields'  => ['email' => 'string'],
+            'indexes' => [['columns' => ['email'], 'unique' => true]],
+        ]);
+
+        $sql = $this->builder->buildUp($schema, [], 'database');
 
         $this->assertStringContainsString('UNIQUE INDEX uix_users_email (email)', $sql);
+        $this->assertStringNotContainsString('tenant_id', $sql);
     }
 
     public function test_build_up_emits_composite_index(): void
@@ -186,6 +200,6 @@ class MigrationBuilderTest extends TestCase
         $this->assertStringContainsString('product_id INT NOT NULL', $sql);
         $this->assertStringContainsString('FOREIGN KEY (order_id) REFERENCES orders(id)', $sql);
         $this->assertStringContainsString('FOREIGN KEY (product_id) REFERENCES products(id)', $sql);
-        $this->assertStringContainsString('UNIQUE INDEX uix_order_items_order_id_product_id', $sql);
+        $this->assertStringContainsString('UNIQUE INDEX uix_order_items_tenant_id_order_id_product_id', $sql);
     }
 }

--- a/tests/Generator/Schema/EntitySchemaTest.php
+++ b/tests/Generator/Schema/EntitySchemaTest.php
@@ -74,4 +74,9 @@ class EntitySchemaTest extends TestCase
         $schema  = $this->schema(['indexes' => $indexes]);
         $this->assertSame($indexes, $schema->getIndexes());
     }
+
+    public function test_get_primary_key_returns_id(): void
+    {
+        $this->assertSame('id', $this->schema()->getPrimaryKey());
+    }
 }

--- a/tests/Generator/Schema/EntitySchemaTest.php
+++ b/tests/Generator/Schema/EntitySchemaTest.php
@@ -20,16 +20,6 @@ class EntitySchemaTest extends TestCase
         $this->assertSame('Order', $this->schema()->getEntityName());
     }
 
-    public function test_is_multi_tenant_defaults_false(): void
-    {
-        $this->assertFalse($this->schema()->isMultiTenant());
-    }
-
-    public function test_is_multi_tenant_true_when_set(): void
-    {
-        $this->assertTrue($this->schema(['multiTenant' => true])->isMultiTenant());
-    }
-
     public function test_has_timestamps_defaults_false(): void
     {
         $this->assertFalse($this->schema()->hasTimestamps());
@@ -46,14 +36,6 @@ class EntitySchemaTest extends TestCase
 
         $this->assertArrayHasKey('id', $fields);
         $this->assertArrayHasKey('total', $fields);
-    }
-
-    public function test_get_fields_appends_tenant_id_when_multi_tenant(): void
-    {
-        $fields = $this->schema(['multiTenant' => true])->getFields();
-
-        $this->assertArrayHasKey('tenant_id', $fields);
-        $this->assertSame('string', $fields['tenant_id']);
     }
 
     public function test_get_fields_appends_timestamps_when_enabled(): void

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -170,4 +170,39 @@ class RequestTest extends TestCase
         $this->assertSame(['id' => 1], $request->getAttribute('user'));
         $this->assertSame('admin', $request->getAttribute('role'));
     }
+
+    // ── json() ─────────────────────────────────────────────────────────────────
+
+    public function test_json_returns_entire_body_array(): void
+    {
+        $request = new Request(body: ['name' => 'Alice', 'age' => 30]);
+
+        $this->assertSame(['name' => 'Alice', 'age' => 30], $request->json());
+    }
+
+    public function test_json_returns_empty_array_when_no_body(): void
+    {
+        $request = new Request();
+
+        $this->assertSame([], $request->json());
+    }
+
+    // ── capture() JSON content type ───────────────────────────────────────────
+
+    public function test_capture_uses_empty_body_when_json_content_type_but_no_input(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_SERVER['REQUEST_URI']    = '/api/items';
+        $_SERVER['CONTENT_TYPE']   = 'application/json';
+        $_POST = [];
+
+        $request = Request::capture();
+
+        $this->assertSame('POST', $request->method());
+        $this->assertSame([], $request->json());
+
+        unset($_SERVER['CONTENT_TYPE']);
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        unset($_SERVER['REQUEST_URI']);
+    }
 }

--- a/tests/Repository/BaseRepositoryTest.php
+++ b/tests/Repository/BaseRepositoryTest.php
@@ -262,6 +262,15 @@ class BaseRepositoryTest extends TestCase
         $this->repo('database')->update(1, ['`injected`' => 'value']);
     }
 
+    public function test_resolve_table_name_derives_from_class_name(): void
+    {
+        $repo = (new \ReflectionClass(WidgetRepository::class))->newInstanceWithoutConstructor();
+        $method = (new \ReflectionClass(BaseRepository::class))->getMethod('resolveTableName');
+        $method->setAccessible(true);
+
+        $this->assertSame('widgets', $method->invoke($repo));
+    }
+
     public function test_transaction_methods_delegate_to_pdo(): void
     {
         $this->pdo->allows('beginTransaction')->once()->andReturn(true);

--- a/tests/Repository/BaseRepositoryTest.php
+++ b/tests/Repository/BaseRepositoryTest.php
@@ -160,11 +160,13 @@ class BaseRepositoryTest extends TestCase
             ->andReturn(true);
 
         $this->pdo->allows('prepare')->andReturn($stmt);
+        $this->pdo->allows('lastInsertId')->andReturn('42');
 
         $result = $this->repo('shared')->create(['name' => 'Alice']);
 
         $this->assertArrayHasKey('tenant_id', $result);
         $this->assertSame('acme', $result['tenant_id']);
+        $this->assertSame(42, $result['id']);
     }
 
     public function test_create_database_strategy_does_not_inject_tenant_id(): void
@@ -176,10 +178,12 @@ class BaseRepositoryTest extends TestCase
             ->andReturn(true);
 
         $this->pdo->allows('prepare')->andReturn($stmt);
+        $this->pdo->allows('lastInsertId')->andReturn('7');
 
         $result = $this->repo('database')->create(['name' => 'Alice']);
 
         $this->assertArrayNotHasKey('tenant_id', $result);
+        $this->assertSame(7, $result['id']);
     }
 
     public function test_update_shared_strategy_appends_tenant_clause(): void

--- a/tests/Repository/BaseRepositoryTest.php
+++ b/tests/Repository/BaseRepositoryTest.php
@@ -265,10 +265,10 @@ class BaseRepositoryTest extends TestCase
     public function test_resolve_table_name_derives_from_class_name(): void
     {
         $repo = (new \ReflectionClass(WidgetRepository::class))->newInstanceWithoutConstructor();
-        $method = (new \ReflectionClass(BaseRepository::class))->getMethod('resolveTableName');
-        $method->setAccessible(true);
 
-        $this->assertSame('widgets', $method->invoke($repo));
+        $result = \Closure::bind(fn() => $this->resolveTableName(), $repo, BaseRepository::class)();
+
+        $this->assertSame('widgets', $result);
     }
 
     public function test_transaction_methods_delegate_to_pdo(): void

--- a/tests/Tenant/TenantServiceTest.php
+++ b/tests/Tenant/TenantServiceTest.php
@@ -71,7 +71,7 @@ class TenantServiceTest extends TestCase
         $this->assertTrue(true);
     }
 
-    public function test_onboard_provisions_and_registers_tenant(): void
+    public function test_onboard_database_strategy_provisions_and_registers_tenant(): void
     {
         /** @var MockInterface&TenantRepository $repo */
         $repo = Mockery::mock(TenantRepository::class);
@@ -82,7 +82,24 @@ class TenantServiceTest extends TestCase
         $provisioner = Mockery::mock(TenantProvisioner::class);
         $provisioner->expects('create')->with('acme')->once();
 
-        $service = new TenantService($this->config(), $repo, $provisioner);
+        $service = new TenantService($this->config('database'), $repo, $provisioner);
+        $service->onboard('acme', 'Acme Corp');
+
+        $this->assertTrue(true);
+    }
+
+    public function test_onboard_shared_strategy_registers_without_provisioning(): void
+    {
+        /** @var MockInterface&TenantRepository $repo */
+        $repo = Mockery::mock(TenantRepository::class);
+        $repo->allows('exists')->with('acme')->andReturn(false);
+        $repo->expects('create')->with('acme', 'Acme Corp')->once();
+
+        /** @var MockInterface&TenantProvisioner $provisioner */
+        $provisioner = Mockery::mock(TenantProvisioner::class);
+        $provisioner->expects('create')->never();
+
+        $service = new TenantService($this->config('shared'), $repo, $provisioner);
         $service->onboard('acme', 'Acme Corp');
 
         $this->assertTrue(true);


### PR DESCRIPTION
- **`bin/ef` autoload path** — Fixed resolution when installed as a Composer dependency (previously resolved inside the vendor package directory)
- **Console commands config path** — All CLI commands now use `getcwd() . '/config'` instead of `__DIR__`-relative paths, so they work correctly from any project root
- **Table name pluralisation** — Added `Str::toTableName()` with proper snake_case and English pluralisation (`JournalEntry` → `journal_entries`, not `journalentrys`). Used consistently across `MigrationBuilder`, `EntityBuilder`, and `BaseRepository`
- **Strategy-aware migrations** — `MigrationBuilder` now accepts a `$strategy` parameter; `tenant_id` column is only emitted for the `shared` strategy. `GenerateCommand` and `GenerateAllCommand` read `tenancy.strategy` from `config/application.yaml` and pass it through
- **Tenant-scoped unique indexes** — Unique indexes in `shared` strategy automatically prepend `tenant_id` as the first column, preventing cross-tenant unique constraint violations
- **FK columns** — `belongsTo` relations now emit `INT NOT NULL` FK columns (previously missing `NOT NULL`)
- **`datetime` type** — Maps to `DATETIME` SQL type (previously fell through to `TEXT`)
- **`BaseRepository::create()`** — Now returns the inserted row with `id` populated via `lastInsertId()`
- **`MigrationRunner` output** — Accepts an injectable `?callable $output` in the constructor; defaults to `echo`. Console commands inject `$output->writeln()` for Symfony Console formatting
- **`TenantService::onboard()`** — Only calls `TenantProvisioner::create()` for `database` strategy; `shared` strategy registers the tenant row without provisioning a database
- **`Request::capture()`** — Detects `application/json` Content-Type and parses `php://input` instead of relying on `$_POST`. Added `json()` helper method